### PR TITLE
Configure graceful shutdown for tonic example

### DIFF
--- a/examples/tonic-example/Cargo.toml
+++ b/examples/tonic-example/Cargo.toml
@@ -8,7 +8,7 @@ examples-util = { path = "../../examples-util" }
 
 tonic = "0.12"
 prost = "0.13"
-tokio = { workspace = true, features = ["rt-multi-thread"] }
+tokio = { workspace = true, features = ["rt-multi-thread", "signal"] }
 log = { workspace = true }
 tower = { workspace = true }
 env_logger = { workspace = true }


### PR DESCRIPTION
Without that, this example may leave keycloak docker containers running.