### PR TITLE
Add more paths for OIDC discovery attempts

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -475,15 +475,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "crc32fast"
-version = "1.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a97769d94ddab943e4510d138150169a2758b5ef3eb191a9ee688de3e23ef7b3"
-dependencies = [
- "cfg-if",
-]
-
-[[package]]
 name = "crypto-common"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -731,16 +722,6 @@ name = "fixedbitset"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
-
-[[package]]
-name = "flate2"
-version = "1.0.34"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1b589b4dc103969ad3cf85c950899926ec64300a1a46d76c03a6072957036f0"
-dependencies = [
- "crc32fast",
- "miniz_oxide",
-]
 
 [[package]]
 name = "fnv"
@@ -2987,13 +2968,13 @@ dependencies = [
  "mockall",
  "pin-project",
  "rand",
+ "reqwest",
  "rsa",
  "serde",
  "serde_json",
  "serde_with",
  "tokio",
  "tower 0.4.13",
- "ureq",
  "wiremock",
 ]
 
@@ -3114,24 +3095,6 @@ name = "untrusted"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
-
-[[package]]
-name = "ureq"
-version = "2.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b74fc6b57825be3373f7054754755f03ac3a8f5d70015ccad699ba2029956f4a"
-dependencies = [
- "base64 0.22.1",
- "flate2",
- "log",
- "once_cell",
- "rustls",
- "rustls-pki-types",
- "serde",
- "serde_json",
- "url",
- "webpki-roots",
-]
 
 [[package]]
 name = "url"
@@ -3282,15 +3245,6 @@ checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
-]
-
-[[package]]
-name = "webpki-roots"
-version = "0.26.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "841c67bff177718f1d4dfefde8d8f0e78f9b6589319ba88312f567fc5841a958"
-dependencies = [
- "rustls-pki-types",
 ]
 
 [[package]]

--- a/examples/axum-example/src/main.rs
+++ b/examples/axum-example/src/main.rs
@@ -19,6 +19,7 @@ async fn main() {
             oidc_provider_host, oidc_provider_port
         ))
         .build()
+        .await
         .expect("Failed to build OAuth2ResourceServer");
 
     let app = Router::new()

--- a/examples/salvo-example/src/main.rs
+++ b/examples/salvo-example/src/main.rs
@@ -18,6 +18,7 @@ async fn main() {
             oidc_provider_host, oidc_provider_port
         ))
         .build()
+        .await
         .expect("Failed to build OAuth2ResourceServer");
 
     let router = Router::new()

--- a/examples/tonic-example/src/main.rs
+++ b/examples/tonic-example/src/main.rs
@@ -27,6 +27,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             oidc_provider_host, oidc_provider_port
         ))
         .build()
+        .await
         .expect("Failed to build OAuth2ResourceServer");
 
     let addr = "[::1]:50051".parse()?;

--- a/tower-oauth2-resource-server/Cargo.toml
+++ b/tower-oauth2-resource-server/Cargo.toml
@@ -10,11 +10,11 @@ http = "1.1.0"
 jsonwebtoken = "9.3.0"
 log = { workspace = true }
 pin-project = "1.1.5"
+reqwest = { version = "0.12.8", features = ["json"] }
 serde = "1.0.210"
 serde_with = "3.9.0"
 tokio = { workspace = true, features = ["rt", "sync", "time"] }
 tower = { workspace = true }
-ureq = { version = "2.9.7", features = ["json"] }
 
 [dev-dependencies]
 base64 = "0.22.1"

--- a/tower-oauth2-resource-server/src/jwks.rs
+++ b/tower-oauth2-resource-server/src/jwks.rs
@@ -76,10 +76,12 @@ impl DecodingKeysProvider for JwksDecodingKeysProvider {
 }
 
 async fn fetch_jwks(jwks_uri: &str) -> Result<JwkSet, JwkError> {
-    let response = reqwest::get(jwks_uri).await
+    let response = reqwest::get(jwks_uri)
+        .await
         .map_err(|_| JwkError::FetchFailed)?;
     let parsed = response
-        .json::<JwkSet>().await
+        .json::<JwkSet>()
+        .await
         .map_err(|_| JwkError::ParseFailed)?;
     Ok(parsed)
 }

--- a/tower-oauth2-resource-server/src/jwks.rs
+++ b/tower-oauth2-resource-server/src/jwks.rs
@@ -76,11 +76,10 @@ impl DecodingKeysProvider for JwksDecodingKeysProvider {
 }
 
 async fn fetch_jwks(jwks_uri: &str) -> Result<JwkSet, JwkError> {
-    let response = ureq::get(jwks_uri)
-        .call()
+    let response = reqwest::get(jwks_uri).await
         .map_err(|_| JwkError::FetchFailed)?;
     let parsed = response
-        .into_json::<JwkSet>()
+        .json::<JwkSet>().await
         .map_err(|_| JwkError::ParseFailed)?;
     Ok(parsed)
 }

--- a/tower-oauth2-resource-server/src/server.rs
+++ b/tower-oauth2-resource-server/src/server.rs
@@ -29,13 +29,15 @@ where
         OAuth2ResourceServerBuilder::new()
     }
 
-    pub(crate) fn new(
+    pub(crate) async fn new(
         issuer_uri: String,
         audiences: Vec<String>,
         jwk_set_refresh_interval: Duration,
         claims_validation_spec: Option<ClaimsValidationSpec>,
     ) -> Result<OAuth2ResourceServer<Claims>, Box<dyn Error>> {
-        let config = OidcConfigProvider::from_issuer_uri(&issuer_uri)?.config;
+        let config = OidcConfigProvider::from_issuer_uri(&issuer_uri)
+            .await?
+            .config;
         info!(
             "Successfully fetched oidc config for issuer: {:?}",
             &issuer_uri
@@ -137,7 +139,7 @@ where
         self
     }
 
-    pub fn build(self) -> Result<OAuth2ResourceServer<Claims>, Box<dyn Error>> {
+    pub async fn build(self) -> Result<OAuth2ResourceServer<Claims>, Box<dyn Error>> {
         let issuer_uri = self
             .issuer_uri
             .ok_or(InvalidParametersError::new("issuer_uri is required"))?;
@@ -147,6 +149,7 @@ where
             self.jwk_set_refresh_interval,
             self.claims_validation_spec,
         )
+        .await
     }
 }
 


### PR DESCRIPTION
This is similar to how [Spring Security OAuth2 Resource Server](https://teams.microsoft.com/l/message/19:meeting_NzQ4YzAwNmItMmE3ZS00Mjg2LTgxZjAtNjBjZWZiM2MxNmYz@thread.v2/1729857371105?context=%7B%22contextType%22%3A%22chat%22%7D) works.