### PR TITLE
Add jwks_uri as property

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,18 @@ Tower middleware that provides JWT authorization against an OpenID Connect (OIDC
 
 Main inspiration for this middleware (both in naming and functionality) is [Spring Security OAuth 2.0 Resource Server](https://docs.spring.io/spring-security/reference/servlet/oauth2/resource-server/index.html).
 
+## Configuration
+
+The `issuer_uri` property is used to configure what authorization server to use.
+
+On startup, the OIDC Provider Configuration endpoint (`<issuer_uri>/.well-known/openid-configuration`) will be queried in order to self-configure the middleware.
+A consequence of this is that the authorization server must be available when the middleware is started.
+
+In cases where the middleware must be able to start independently from the authorization server, the `jwks_uri` property can be set.
+This will prevent the self-configuration on start up.
+
+**Note** that it's still required to provide `issuer_uri`, since it's used to validate the `iss` claim in JWTs.
+
 ## Example usage
 
 Check the [examples](./examples/).

--- a/tower-oauth2-resource-server/src/error.rs
+++ b/tower-oauth2-resource-server/src/error.rs
@@ -1,6 +1,12 @@
 use http::{header::WWW_AUTHENTICATE, HeaderValue, Response, StatusCode};
 
 #[derive(Debug)]
+pub enum StartupError {
+    InvalidParameter(String),
+    OidcDiscoveryFailed,
+}
+
+#[derive(Debug)]
 pub enum JwkError {
     FetchFailed,
     ParseFailed,

--- a/tower-oauth2-resource-server/src/oidc.rs
+++ b/tower-oauth2-resource-server/src/oidc.rs
@@ -4,7 +4,6 @@ use serde::Deserialize;
 
 #[derive(Clone, Debug, Deserialize)]
 pub(crate) struct OidcConfig {
-    pub issuer: String,
     pub jwks_uri: String,
     pub claims_supported: Option<Vec<String>>,
 }

--- a/tower-oauth2-resource-server/src/validation.rs
+++ b/tower-oauth2-resource-server/src/validation.rs
@@ -1,7 +1,5 @@
 use std::fmt::Display;
 
-use crate::oidc::OidcConfig;
-
 #[derive(Debug, Default)]
 pub struct ClaimsValidationSpec {
     pub iss: Option<String>,
@@ -17,25 +15,6 @@ impl ClaimsValidationSpec {
 
     pub fn recommended(issuer: &str, audiences: Vec<String>) -> Self {
         Self::new().exp(true).nbf(true).iss(issuer).aud(audiences)
-    }
-
-    pub(crate) fn from_oidc_config(oidc_config: &OidcConfig, audiences: &[String]) -> Option<Self> {
-        match &oidc_config.claims_supported {
-            Some(claims_supported) => {
-                let mut spec = ClaimsValidationSpec::new().exp(true);
-                if claims_supported.contains(&"iss".to_owned()) {
-                    spec = spec.iss(&oidc_config.issuer);
-                }
-                if claims_supported.contains(&"nbf".to_owned()) {
-                    spec = spec.nbf(true);
-                }
-                if claims_supported.contains(&"aud".to_owned()) {
-                    spec = spec.aud(audiences.iter().map(|a| a.to_string()).collect());
-                }
-                Some(spec)
-            }
-            None => None,
-        }
     }
 
     pub fn iss(mut self, issuer: &str) -> Self {

--- a/tower-oauth2-resource-server/tests/service.rs
+++ b/tower-oauth2-resource-server/tests/service.rs
@@ -111,7 +111,7 @@ async fn ok() {
         &private_key,
         "good_key",
         serde_json::json!({
-            "iss": "https://auth-server.com",
+            "iss": mock_server.uri(),
             "sub": "Some dude",
             "aud": vec!["https://some-resource-server.com"],
             "nbf": SystemTime::now().duration_since(UNIX_EPOCH).unwrap().as_secs() - 10,


### PR DESCRIPTION
May be used to bypass OIDC discovery, and thus removes the need to have an authorization server available when starting the middleware.