### PR TITLE
Use more flexible string types in builder

### DIFF
--- a/examples/axum-example/src/main.rs
+++ b/examples/axum-example/src/main.rs
@@ -13,8 +13,8 @@ async fn main() {
     info!("Running OIDC provider on port: {}", oidc_provider_port);
 
     let oauth2_resource_server = <OAuth2ResourceServer>::builder()
-        .audiences(vec!["tors-example".to_owned()])
-        .issuer_uri(&format!(
+        .audiences(&["tors-example"])
+        .issuer_uri(format!(
             "http://{}:{}/realms/tors",
             oidc_provider_host, oidc_provider_port
         ))

--- a/examples/salvo-example/src/main.rs
+++ b/examples/salvo-example/src/main.rs
@@ -12,8 +12,8 @@ async fn main() {
     info!("Running OIDC provider on port: {}", oidc_provider_port);
 
     let oauth2_resource_server = <OAuth2ResourceServer>::builder()
-        .audiences(vec!["tors-example".to_owned()])
-        .issuer_uri(&format!(
+        .audiences(&["tors-example"])
+        .issuer_uri(format!(
             "http://{}:{}/realms/tors",
             oidc_provider_host, oidc_provider_port
         ))

--- a/examples/tonic-example/src/main.rs
+++ b/examples/tonic-example/src/main.rs
@@ -21,8 +21,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     info!("Running OIDC provider on port: {}", oidc_provider_port);
 
     let oauth2_resource_server = <OAuth2ResourceServer>::builder()
-        .audiences(vec!["tors-example".to_owned()])
-        .issuer_uri(&format!(
+        .audiences(&["tors-example"])
+        .issuer_uri(format!(
             "http://{}:{}/realms/tors",
             oidc_provider_host, oidc_provider_port
         ))

--- a/tower-oauth2-resource-server/src/server.rs
+++ b/tower-oauth2-resource-server/src/server.rs
@@ -148,18 +148,18 @@ where
         }
     }
 
-    pub fn issuer_uri(mut self, issuer_uri: &str) -> Self {
-        self.issuer_uri = Some(issuer_uri.to_owned());
+    pub fn issuer_uri(mut self, issuer_uri: impl Into<String>) -> Self {
+        self.issuer_uri = Some(issuer_uri.into());
         self
     }
 
-    pub fn jwks_uri(mut self, jwks_uri: &str) -> Self {
-        self.jwks_uri = Some(jwks_uri.to_owned());
+    pub fn jwks_uri(mut self, jwks_uri: impl Into<String>) -> Self {
+        self.jwks_uri = Some(jwks_uri.into());
         self
     }
 
-    pub fn audiences(mut self, audiences: Vec<String>) -> Self {
-        self.audiences = audiences;
+    pub fn audiences(mut self, audiences: &[impl ToString]) -> Self {
+        self.audiences = audiences.iter().map(|aud| aud.to_string()).collect();
         self
     }
 

--- a/tower-oauth2-resource-server/tests/service.rs
+++ b/tower-oauth2-resource-server/tests/service.rs
@@ -117,7 +117,7 @@ async fn default_auth_layer(
     audiences: &[impl ToString],
 ) -> OAuth2ResourceServerLayer<DefaultClaims> {
     <OAuth2ResourceServer>::builder()
-        .issuer_uri(&mock_server.uri())
+        .issuer_uri(mock_server.uri())
         .audiences(audiences)
         .build()
         .await


### PR DESCRIPTION
By accepting Into<String> the consumer can provide either an owned string or e.g. a &static str.