### PR TITLE
Fix bug related to jwks url

### DIFF
--- a/tower-oauth2-resource-server/src/oidc.rs
+++ b/tower-oauth2-resource-server/src/oidc.rs
@@ -10,7 +10,7 @@ use crate::error::StartupError;
 
 #[derive(Clone, Debug, Deserialize)]
 pub(crate) struct OidcConfig {
-    pub jwks_url: Url,
+    pub jwks_uri: Url,
     pub claims_supported: Option<Vec<String>>,
 }
 

--- a/tower-oauth2-resource-server/src/server.rs
+++ b/tower-oauth2-resource-server/src/server.rs
@@ -128,7 +128,7 @@ async fn resolve_config(
             claims_spec = claims_spec.nbf(true);
         }
     }
-    Ok((oidc_config.jwks_url, claims_spec))
+    Ok((oidc_config.jwks_uri, claims_spec))
 }
 
 #[cfg(test)]
@@ -146,7 +146,7 @@ mod tests {
         ctx.expect()
             .returning(|_| {
                 Ok(OidcConfig {
-                    jwks_url: "http://some-issuer.com/jwks".parse::<Url>().unwrap(),
+                    jwks_uri: "http://some-issuer.com/jwks".parse::<Url>().unwrap(),
                     claims_supported: None,
                 })
             })

--- a/tower-oauth2-resource-server/tests/common/mod.rs
+++ b/tower-oauth2-resource-server/tests/common/mod.rs
@@ -15,7 +15,7 @@ use wiremock::{
 #[derive(Serialize)]
 struct OpenIdConfig {
     pub issuer: String,
-    pub jwks_url: String,
+    pub jwks_uri: String,
 }
 
 #[derive(Serialize)]
@@ -41,7 +41,7 @@ pub async fn mock_oidc_config(mock_server: &MockServer, issuer: &str) {
         .and(path("/.well-known/openid-configuration"))
         .respond_with(ResponseTemplate::new(200).set_body_json(OpenIdConfig {
             issuer: issuer.to_owned(),
-            jwks_url: format!("{}/jwks", &mock_server.uri()),
+            jwks_uri: format!("{}/jwks", &mock_server.uri()),
         }))
         .mount(mock_server)
         .await;


### PR DESCRIPTION
These properties should not have been renamed, since the url is exposed on the jwks_uri property according OIDC specification.