### PR TITLE
Put JWT extraction in separate module

### DIFF
--- a/tower-oauth2-resource-server/src/error.rs
+++ b/tower-oauth2-resource-server/src/error.rs
@@ -55,3 +55,17 @@ impl Display for StartupError {
     }
 }
 impl Error for StartupError {}
+
+impl Display for JwkError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{:?}", self)
+    }
+}
+impl Error for JwkError {}
+
+impl Display for AuthError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{:?}", self)
+    }
+}
+impl Error for AuthError {}

--- a/tower-oauth2-resource-server/src/jwt_extract.rs
+++ b/tower-oauth2-resource-server/src/jwt_extract.rs
@@ -20,3 +20,44 @@ impl JwtExtractor for BearerTokenJwtExtractor {
             .to_owned())
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use http::HeaderValue;
+
+    use super::*;
+
+    #[test]
+    fn test_missing_authorization() {
+        let headers = HeaderMap::new();
+        let result = BearerTokenJwtExtractor {}.extract_jwt(&headers);
+
+        assert!(result.is_err());
+        assert_eq!(result.unwrap_err(), AuthError::MissingAuthorizationHeader);
+    }
+
+    #[test]
+    fn test_missing_bearer_prefix() {
+        let mut headers = HeaderMap::new();
+        headers.insert(
+            "Authorization",
+            HeaderValue::from_str("Boarer XXX").unwrap(),
+        );
+        let result = BearerTokenJwtExtractor {}.extract_jwt(&headers);
+
+        assert!(result.is_err());
+        assert_eq!(result.unwrap_err(), AuthError::InvalidAuthorizationHeader);
+    }
+
+    #[test]
+    fn test_ok() {
+        let mut headers = HeaderMap::new();
+        headers.insert(
+            "Authorization",
+            HeaderValue::from_str("Bearer XXX").unwrap(),
+        );
+        let result = BearerTokenJwtExtractor {}.extract_jwt(&headers);
+
+        assert!(result.is_ok());
+    }
+}

--- a/tower-oauth2-resource-server/src/jwt_extract.rs
+++ b/tower-oauth2-resource-server/src/jwt_extract.rs
@@ -1,0 +1,22 @@
+use http::HeaderMap;
+
+use crate::error::AuthError;
+
+pub trait JwtExtractor {
+    fn extract_jwt(&self, headers: &HeaderMap) -> Result<String, AuthError>;
+}
+
+pub struct BearerTokenJwtExtractor;
+
+impl JwtExtractor for BearerTokenJwtExtractor {
+    fn extract_jwt(&self, headers: &HeaderMap) -> Result<String, AuthError> {
+        Ok(headers
+            .get(http::header::AUTHORIZATION)
+            .ok_or(AuthError::MissingAuthorizationHeader)?
+            .to_str()
+            .map_err(|_| AuthError::InvalidAuthorizationHeader)?
+            .strip_prefix("Bearer ")
+            .ok_or(AuthError::InvalidAuthorizationHeader)?
+            .to_owned())
+    }
+}

--- a/tower-oauth2-resource-server/src/jwt_validate.rs
+++ b/tower-oauth2-resource-server/src/jwt_validate.rs
@@ -4,7 +4,6 @@ use std::{
 };
 
 use async_trait::async_trait;
-use http::HeaderMap;
 use jsonwebtoken::{
     decode, decode_header,
     jwk::{AlgorithmParameters, Jwk, JwkSet, KeyAlgorithm},
@@ -19,25 +18,6 @@ use crate::{
     jwks::JwksConsumer,
     validation::ClaimsValidationSpec,
 };
-
-pub trait JwtExtractor {
-    fn extract_jwt(&self, headers: &HeaderMap) -> Result<String, AuthError>;
-}
-
-pub struct BearerTokenJwtExtractor;
-
-impl JwtExtractor for BearerTokenJwtExtractor {
-    fn extract_jwt(&self, headers: &HeaderMap) -> Result<String, AuthError> {
-        Ok(headers
-            .get(http::header::AUTHORIZATION)
-            .ok_or(AuthError::MissingAuthorizationHeader)?
-            .to_str()
-            .map_err(|_| AuthError::InvalidAuthorizationHeader)?
-            .strip_prefix("Bearer ")
-            .ok_or(AuthError::InvalidAuthorizationHeader)?
-            .to_owned())
-    }
-}
 
 #[async_trait]
 pub trait JwtValidator<Claims> {

--- a/tower-oauth2-resource-server/src/lib.rs
+++ b/tower-oauth2-resource-server/src/lib.rs
@@ -6,5 +6,6 @@ pub mod validation;
 
 mod error;
 mod jwks;
-mod jwt;
+mod jwt_extract;
+mod jwt_validate;
 mod oidc;


### PR DESCRIPTION
In addition:

- Add tests for JWT extraction
- Write a debug log when JWT extraction fails (it's logged when validation fails, extraction should be consistent)
- Rename JWT module that performs validation