### PR TITLE
Fix README path

### DIFF
--- a/tower-oauth2-resource-server/Cargo.toml
+++ b/tower-oauth2-resource-server/Cargo.toml
@@ -5,7 +5,7 @@ keywords = ["jwt", "oidc", "oauth2", "authorizer"]
 license = "MIT"
 homepage = "https://github.com/Dunklas/tower-oauth2-resource-server"
 repository = "https://github.com/Dunklas/tower-oauth2-resource-server"
-readme = "../README.md"
+readme = "README.md"
 version = "0.1.0"
 edition = "2021"
 

--- a/tower-oauth2-resource-server/Cargo.toml
+++ b/tower-oauth2-resource-server/Cargo.toml
@@ -8,6 +8,7 @@ repository = "https://github.com/Dunklas/tower-oauth2-resource-server"
 readme = "README.md"
 version = "0.1.0"
 edition = "2021"
+exclude = ["tests"]
 
 [dependencies]
 async-trait = "0.1.83"

--- a/tower-oauth2-resource-server/README.md
+++ b/tower-oauth2-resource-server/README.md
@@ -1,0 +1,1 @@
+../README.md

--- a/tower-oauth2-resource-server/src/lib.rs
+++ b/tower-oauth2-resource-server/src/lib.rs
@@ -1,4 +1,4 @@
-#![doc = include_str!("../../README.md")]
+#![doc = include_str!("../README.md")]
 
 /// Builder used to construct an [OAuth2ResourceServer](crate::server::OAuth2ResourceServer) instance.
 ///


### PR DESCRIPTION
The previous path worked fine when compiling, etc. When running cargo publish
however, the crate wouldn't compile due to include_str! pointing to an
invalid file.

Only crate content is included when running publish, so my README.md in
repository root wasn't included. I've now added a symbolic link to the
README in repository root, which seems to work fine.