### PR TITLE
Fix permissions for gh release

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -16,6 +16,13 @@ jobs:
             --locked \
             --package tower-oauth2-resource-server \
             --token ${{ secrets.CRATES_IO_TOKEN }}
+
+  create-release:
+    runs-on: ubuntu-latest
+    needs: publish
+    permissions:
+      contents: write
+    steps:
       - uses: softprops/action-gh-release@v2
         with:
           generate_release_notes: true


### PR DESCRIPTION
It requires content: write
Extracted to new job to limit exposure of new permission.