### PR TITLE
Set MSRV to 1.45.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3295,7 +3295,7 @@ checksum = "121c2a6cda46980bb0fcd1647ffaf6cd3fc79a013de288782836f6df9c48780e"
 
 [[package]]
 name = "tower-oauth2-resource-server"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "async-trait",
  "base64 0.22.1",

--- a/examples/salvo-example/Cargo.toml
+++ b/examples/salvo-example/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "salvo-example"
-edition = "2021"
+edition = "2024"
 
 [dependencies]
 tower-oauth2-resource-server = { path = "../../tower-oauth2-resource-server" }

--- a/tower-oauth2-resource-server/Cargo.toml
+++ b/tower-oauth2-resource-server/Cargo.toml
@@ -6,10 +6,10 @@ license = "MIT"
 homepage = "https://github.com/Dunklas/tower-oauth2-resource-server"
 repository = "https://github.com/Dunklas/tower-oauth2-resource-server"
 readme = "README.md"
-version = "0.2.0"
+version = "0.2.1"
 
-edition = "2024"
-rust-version = "1.85.0"
+edition = "2018"
+rust-version = "1.31.0"
 exclude = ["tests"]
 
 [dependencies]

--- a/tower-oauth2-resource-server/Cargo.toml
+++ b/tower-oauth2-resource-server/Cargo.toml
@@ -9,7 +9,7 @@ readme = "README.md"
 version = "0.2.1"
 
 edition = "2018"
-rust-version = "1.31.0"
+rust-version = "1.45.0"
 exclude = ["tests"]
 
 [dependencies]

--- a/tower-oauth2-resource-server/src/claims.rs
+++ b/tower-oauth2-resource-server/src/claims.rs
@@ -1,7 +1,7 @@
 use std::fmt::Display;
 
 use serde::{Deserialize, Serialize};
-use serde_with::{OneOrMany, formats::PreferMany, serde_as};
+use serde_with::{formats::PreferMany, serde_as, OneOrMany};
 
 #[serde_as]
 #[derive(Clone, Debug, Deserialize, Serialize)]

--- a/tower-oauth2-resource-server/src/error.rs
+++ b/tower-oauth2-resource-server/src/error.rs
@@ -1,6 +1,6 @@
 use std::{error::Error, fmt::Display};
 
-use http::{HeaderValue, Response, StatusCode, header::WWW_AUTHENTICATE};
+use http::{header::WWW_AUTHENTICATE, HeaderValue, Response, StatusCode};
 use jsonwebtoken::Algorithm;
 
 #[derive(Clone, Debug, PartialEq)]

--- a/tower-oauth2-resource-server/src/jwks.rs
+++ b/tower-oauth2-resource-server/src/jwks.rs
@@ -84,16 +84,17 @@ mod tests {
     use std::time::Instant;
 
     use base64::{
-        Engine, alphabet,
-        engine::{GeneralPurpose, general_purpose},
+        alphabet,
+        engine::{general_purpose, GeneralPurpose},
+        Engine,
     };
     use jsonwebtoken::jwk::Jwk;
-    use rsa::{RsaPrivateKey, RsaPublicKey, traits::PublicKeyParts};
+    use rsa::{traits::PublicKeyParts, RsaPrivateKey, RsaPublicKey};
     use serde_json::json;
     use tokio::sync::RwLock;
     use wiremock::{
-        Mock, MockServer, ResponseTemplate,
         matchers::{method, path},
+        Mock, MockServer, ResponseTemplate,
     };
 
     use super::*;

--- a/tower-oauth2-resource-server/src/jwt_validate.rs
+++ b/tower-oauth2-resource-server/src/jwt_validate.rs
@@ -5,8 +5,9 @@ use std::{
 
 use async_trait::async_trait;
 use jsonwebtoken::{
-    Algorithm, DecodingKey, Validation, decode, decode_header,
+    decode, decode_header,
     jwk::{Jwk, JwkSet, KeyAlgorithm},
+    Algorithm, DecodingKey, Validation,
 };
 use log::{info, warn};
 use serde::de::DeserializeOwned;
@@ -154,18 +155,20 @@ fn parse_key_alg(key_alg: KeyAlgorithm) -> Option<Algorithm> {
 #[cfg(test)]
 mod tests {
     use base64::{
-        Engine, alphabet,
+        alphabet,
         engine::{self, general_purpose},
+        Engine,
     };
     use jsonwebtoken::{
-        EncodingKey, Header, encode,
+        encode,
         errors::ErrorKind,
         jwk::{Jwk, JwkSet},
+        EncodingKey, Header,
     };
     use lazy_static::lazy_static;
-    use rsa::{RsaPrivateKey, RsaPublicKey, pkcs1::EncodeRsaPrivateKey, traits::PublicKeyParts};
+    use rsa::{pkcs1::EncodeRsaPrivateKey, traits::PublicKeyParts, RsaPrivateKey, RsaPublicKey};
     use serde::Deserialize;
-    use serde_json::{Value, json};
+    use serde_json::{json, Value};
     use std::time::{SystemTime, UNIX_EPOCH};
 
     use crate::{error::AuthError, jwks::JwksConsumer, validation::ClaimsValidationSpec};

--- a/tower-oauth2-resource-server/src/layer.rs
+++ b/tower-oauth2-resource-server/src/layer.rs
@@ -1,11 +1,11 @@
-use futures_util::{Future, future::BoxFuture};
+use futures_util::{future::BoxFuture, Future};
 use http::{Request, Response};
 use pin_project::pin_project;
 use serde::de::DeserializeOwned;
 
 use std::{
     pin::Pin,
-    task::{Context, Poll, ready},
+    task::{ready, Context, Poll},
 };
 use tower::{Layer, Service};
 

--- a/tower-oauth2-resource-server/src/oidc.rs
+++ b/tower-oauth2-resource-server/src/oidc.rs
@@ -93,16 +93,10 @@ mod tests {
             .map(|p| p.to_string())
             .collect::<HashSet<_>>();
         assert_eq!(paths.len(), 3);
-        assert!(
-            paths.contains(
-                "https://authorization-server.com/issuer/.well-known/openid-configuration"
-            )
-        );
-        assert!(
-            paths.contains(
-                "https://authorization-server.com/.well-known/openid-configuration/issuer"
-            )
-        );
+        assert!(paths
+            .contains("https://authorization-server.com/issuer/.well-known/openid-configuration"));
+        assert!(paths
+            .contains("https://authorization-server.com/.well-known/openid-configuration/issuer"));
         assert!(paths.contains(
             "https://authorization-server.com/.well-known/oauth-authorization-server/issuer"
         ));
@@ -121,16 +115,10 @@ mod tests {
             .map(|p| p.to_string())
             .collect::<HashSet<_>>();
 
-        assert!(
-            paths.contains(
-                "https://authorization-server.com/issuer/.well-known/openid-configuration"
-            )
-        );
-        assert!(
-            paths.contains(
-                "https://authorization-server.com/.well-known/openid-configuration/issuer"
-            )
-        );
+        assert!(paths
+            .contains("https://authorization-server.com/issuer/.well-known/openid-configuration"));
+        assert!(paths
+            .contains("https://authorization-server.com/.well-known/openid-configuration/issuer"));
         assert!(paths.contains(
             "https://authorization-server.com/.well-known/oauth-authorization-server/issuer"
         ));
@@ -146,14 +134,9 @@ mod tests {
             .collect::<HashSet<_>>();
 
         assert_eq!(paths.len(), 2);
-        assert!(
-            paths.contains("https://authorization-server.com/.well-known/openid-configuration")
-        );
-        assert!(
-            paths.contains(
-                "https://authorization-server.com/.well-known/oauth-authorization-server"
-            )
-        );
+        assert!(paths.contains("https://authorization-server.com/.well-known/openid-configuration"));
+        assert!(paths
+            .contains("https://authorization-server.com/.well-known/oauth-authorization-server"));
     }
 
     #[test]
@@ -166,13 +149,8 @@ mod tests {
             .collect::<HashSet<_>>();
 
         assert_eq!(paths.len(), 2);
-        assert!(
-            paths.contains("https://authorization-server.com/.well-known/openid-configuration")
-        );
-        assert!(
-            paths.contains(
-                "https://authorization-server.com/.well-known/oauth-authorization-server"
-            )
-        );
+        assert!(paths.contains("https://authorization-server.com/.well-known/openid-configuration"));
+        assert!(paths
+            .contains("https://authorization-server.com/.well-known/oauth-authorization-server"));
     }
 }

--- a/tower-oauth2-resource-server/tests/common/mod.rs
+++ b/tower-oauth2-resource-server/tests/common/mod.rs
@@ -1,14 +1,15 @@
 use base64::{
-    Engine, alphabet,
+    alphabet,
     engine::{self, general_purpose},
+    Engine,
 };
-use jsonwebtoken::{EncodingKey, Header, encode};
-use rsa::{RsaPrivateKey, RsaPublicKey, pkcs1::EncodeRsaPrivateKey, traits::PublicKeyParts};
+use jsonwebtoken::{encode, EncodingKey, Header};
+use rsa::{pkcs1::EncodeRsaPrivateKey, traits::PublicKeyParts, RsaPrivateKey, RsaPublicKey};
 use serde::Serialize;
 use serde_json::Value;
 use wiremock::{
-    Mock, MockServer, ResponseTemplate,
     matchers::{method, path},
+    Mock, MockServer, ResponseTemplate,
 };
 
 #[derive(Serialize)]

--- a/tower-oauth2-resource-server/tests/service.rs
+++ b/tower-oauth2-resource-server/tests/service.rs
@@ -2,7 +2,7 @@ use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 use bytes::Bytes;
 use common::{jwt_from, mock_jwks, mock_oidc_config, rsa_key_pair};
-use http::{HeaderName, Request, Response, StatusCode, header::AUTHORIZATION};
+use http::{header::AUTHORIZATION, HeaderName, Request, Response, StatusCode};
 use http_body_util::Full;
 use tokio::time::sleep;
 use tower::{BoxError, Service, ServiceBuilder, ServiceExt};


### PR DESCRIPTION
In the last commit I updated version of salvo which now required rust-version 1.85.0 and edition 2024. The commit resulted in tower-oauth2-resource-server having the same requirements.

In this PR I set edition 2024 on the salvo example crate only.
I've also set the MSRV 1.45.0 (edition 2018) - I believe this is the lowest I can support (usage of strip_prefix in jwt_extract became stable in that version).