### PR TITLE
Use static RSA key pairs in integration tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3084,7 +3084,6 @@ dependencies = [
  "mockall",
  "mockall_double",
  "pin-project",
- "rand 0.8.5",
  "reqwest",
  "serde",
  "serde_json",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -259,12 +259,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
-name = "base64ct"
-version = "1.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c3c1a368f70d6cf7302d78f8f7093da241fb8e8807c05cc9e51a125895a6d5b"
-
-[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -404,12 +398,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3fd119d74b830634cea2a0f58bbd0d54540518a14397557951e79340abc28c0"
 
 [[package]]
-name = "const-oid"
-version = "0.9.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
-
-[[package]]
 name = "cookie"
 version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -525,17 +513,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "092966b41edc516079bdf31ec78a2e0588d1d0c08f78b91d8307215928642b2b"
 
 [[package]]
-name = "der"
-version = "0.7.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f55bf8e7b65898637379c1b74eb1551107c8294ed26d855ceb9fd1a09cfc9bc0"
-dependencies = [
- "const-oid",
- "pem-rfc7468",
- "zeroize",
-]
-
-[[package]]
 name = "deranged"
 version = "0.3.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -552,7 +529,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer",
- "const-oid",
  "crypto-common",
  "subtle",
 ]
@@ -1405,21 +1381,12 @@ name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
-dependencies = [
- "spin",
-]
 
 [[package]]
 name = "libc"
 version = "0.2.169"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5aba8db14291edd000dfcc4d620c7ebfb122c613afb886ca8803fa4e128a20a"
-
-[[package]]
-name = "libm"
-version = "0.2.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ec2a862134d2a7d32d7983ddcdd1c4923530833c9f2ea1a44fc5fa473989058"
 
 [[package]]
 name = "libredox"
@@ -1613,23 +1580,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "num-bigint-dig"
-version = "0.8.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc84195820f291c7697304f3cbdadd1cb7199c0efc917ff5eafd71225c136151"
-dependencies = [
- "byteorder",
- "lazy_static",
- "libm",
- "num-integer",
- "num-iter",
- "num-traits",
- "rand 0.8.5",
- "smallvec",
- "zeroize",
-]
-
-[[package]]
 name = "num-conv"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1645,24 +1595,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "num-iter"
-version = "0.1.45"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1429034a0490724d0075ebb2bc9e875d6503c3cf69e235a8941aa757d83ef5bf"
-dependencies = [
- "autocfg",
- "num-integer",
- "num-traits",
-]
-
-[[package]]
 name = "num-traits"
 version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
- "libm",
 ]
 
 [[package]]
@@ -1799,15 +1737,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "pem-rfc7468"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88b39c9bfcfc231068454382784bb460aae594343fb030d46e9f50a645418412"
-dependencies = [
- "base64ct",
-]
-
-[[package]]
 name = "percent-encoding"
 version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1854,27 +1783,6 @@ name = "pin-utils"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
-
-[[package]]
-name = "pkcs1"
-version = "0.7.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8ffb9f10fa047879315e6625af03c164b16962a5368d724ed16323b68ace47f"
-dependencies = [
- "der",
- "pkcs8",
- "spki",
-]
-
-[[package]]
-name = "pkcs8"
-version = "0.10.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
-dependencies = [
- "der",
- "spki",
-]
 
 [[package]]
 name = "pkg-config"
@@ -2244,26 +2152,6 @@ dependencies = [
  "libc",
  "untrusted",
  "windows-sys 0.52.0",
-]
-
-[[package]]
-name = "rsa"
-version = "0.9.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78928ac1ed176a5ca1d17e578a1825f3d81ca54cf41053a592584b020cfd691b"
-dependencies = [
- "const-oid",
- "digest",
- "num-bigint-dig",
- "num-integer",
- "num-traits",
- "pkcs1",
- "pkcs8",
- "rand_core 0.6.4",
- "signature",
- "spki",
- "subtle",
- "zeroize",
 ]
 
 [[package]]
@@ -2695,16 +2583,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "signature"
-version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
-dependencies = [
- "digest",
- "rand_core 0.6.4",
-]
-
-[[package]]
 name = "simple_asn1"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2746,16 +2624,6 @@ name = "spin"
 version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
-
-[[package]]
-name = "spki"
-version = "0.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d"
-dependencies = [
- "base64ct",
- "der",
-]
 
 [[package]]
 name = "stable_deref_trait"
@@ -3218,7 +3086,6 @@ dependencies = [
  "pin-project",
  "rand 0.8.5",
  "reqwest",
- "rsa",
  "serde",
  "serde_json",
  "serde_with",

--- a/tower-oauth2-resource-server/Cargo.toml
+++ b/tower-oauth2-resource-server/Cargo.toml
@@ -35,7 +35,6 @@ bytes = "1.10.1"
 lazy_static = "1.4.0"
 mockall = "0.13.1"
 rand = "0.8.5"
-rsa = "0.9.8"
 tower = { workspace = true, features = ["util"] }
 tokio = { workspace = true, features = ["rt-multi-thread"] }
 wiremock = "0.6.3"

--- a/tower-oauth2-resource-server/Cargo.toml
+++ b/tower-oauth2-resource-server/Cargo.toml
@@ -34,7 +34,6 @@ http-body-util = "0.1.3"
 bytes = "1.10.1"
 lazy_static = "1.4.0"
 mockall = "0.13.1"
-rand = "0.8.5"
 tower = { workspace = true, features = ["util"] }
 tokio = { workspace = true, features = ["rt-multi-thread"] }
 wiremock = "0.6.3"

--- a/tower-oauth2-resource-server/tests/common/mod.rs
+++ b/tower-oauth2-resource-server/tests/common/mod.rs
@@ -1,10 +1,4 @@
-use base64::{
-    alphabet,
-    engine::{self, general_purpose},
-    Engine,
-};
 use jsonwebtoken::{encode, EncodingKey, Header};
-use rsa::{pkcs1::EncodeRsaPrivateKey, traits::PublicKeyParts, RsaPrivateKey, RsaPublicKey};
 use serde::Serialize;
 use serde_json::Value;
 use wiremock::{
@@ -33,8 +27,37 @@ struct Jwk {
     e: String,
 }
 
-const CUSTOM_ENGINE: engine::GeneralPurpose =
-    engine::GeneralPurpose::new(&alphabet::URL_SAFE, general_purpose::NO_PAD);
+pub const DEFAULT_RSA_PRIVATE_KEY: &str = r#"-----BEGIN PRIVATE KEY-----
+MIIEvQIBADANBgkqhkiG9w0BAQEFAASCBKcwggSjAgEAAoIBAQCgTP9Gu6kc/131
+eIVtcugkzAb7vlnXy3jOIHLY8dNkfGQc56ntoV42P7Xc2YhwviiiP7afGsuFZuAD
+aIFpav3nAqR/ml5Oxz7lDr4Ha4Jyf3E9JArTxj+M1WG2XLeYA52xPhj2ZAg7+ipq
+oTLO63KlkES77Xw2RsZXCQ2Eb2zG9SMVce8ygmzmLAgtoMDYWG4SKggPM7L5mMPy
+n3bzJ7a/wJ09aXXE/GgFd3Yoh7dGShxEPEt54GDfAfxr21Dlnt86aJeIAjz+U3nv
+Nh/TvzJrO8tSUrMKjWlChHbkxTnV3vOAj8jsfYVvk9kZwKZ+83VSnjU58RDIwsvo
+ljKg/bddAgMBAAECggEAToB2kU6simlau7A6c3eOzRpnnxhAikf4UMWeSLTgx7iN
+FIS0+I0KhLmdl9qmEURmxNI73l3yZlGTice/fH8reVqXcXAJGD5GBEm8cQjK2MSl
+kYIZlU1kaNVEpVhxho3ax2Z4Ng2V5L1l0VNA/Qlb2020A25RYok1b4Ec8ArbM/Ep
+ECxHjMjViHlqFLo25AfqxW0Q/TeNyMdYDWn/l6+qw9OI5OYswGwW1xwjL6ElcqnT
+tDDC/wqorxv+sRrTTyxQ1mUg1K2vm7wjml2PlVgjv7P28O0LjlDspPFChVZ2xbp0
++ohEiNARBabqVt1gs/aYmoN8SZ9NDneCCzFSL/P4lwKBgQDT9QQXMB2lgEMaEIS/
+1z2E1ByL6cN7uiqo4rTDrvnLGL/vBqb3751YV/sJubi6Da1QpAZJQ/ssHNs6T1zh
+nImXkSWG+OravA10driJL8wWcKD3bIQOEc6FFrz+t/tiLf6tx5Ok6+vWL89muiWw
+xouU/msV0ZXHcIoKonB2a7sYqwKBgQDBnCQYhbb8T7U248Cd6jv0gaJn5VHA9mF7
+/Wg0oHgAi/TFGlO/1nktkmHbDE0BH4Y9NM3vOmik5ag4tVGFIQU7MkDx9HKo9GnZ
+Tx2OcwpQ5l/02GMO634y2w/zoS1GoGNqWLYVPsK3kyM+LmzAc29fpOBxxomqA1Pw
+SRuVBouAFwKBgHpL5z5R3uk9ZnpFibL/SFm54XbBPK/JLRAhLtexwCN1dlk+Z1yr
+fwgYS5rC9Fk1xwi+e3oOpYBAbiXo4Ni0b5dqglKskSYAV2sZjURqtcFE3zuj+1X6
+5ERaaFY4Ze2ySD6Q5xnDnmIJWAwX3+Nty9/+JF+EfH2E68FTFLzfUCbdAoGBALzB
+k9dslegLdesbxLCwqt9Ie6O7SSdNjeEqP6v/Pr+Zs3tunXQMj3vEmS7MIU8VAvUt
+RBEV6uvJE2amL+IRPV5nMjYyUo8yKvg4T+KPeeFBmQ/G31yubwz50eV+n/uZZxNJ
+hcvUslXzV4rKDDDc2hpvTnreS1y7fdxoCkISbXLlAoGAQ2W04sNMa6sFI/9rAcFv
+yviLtRw4G2epS0AtGhPsy3cPX8XIiRbkQXrZSSV9FSlZyC0Fr1IS8qTCF9rJMawm
+iiVw58CWKo4qO6HQGC/W5nD3maFnHnnp3mtIgfGsWEyc9tgdhFZuTtHxDPTjm/xU
+kTlUuvwRMeoB7RdcxaYHaQo=
+-----END PRIVATE KEY-----"#;
+
+const DEFAULT_RSA_MODULUS: &str = "oEz_RrupHP9d9XiFbXLoJMwG-75Z18t4ziBy2PHTZHxkHOep7aFeNj-13NmIcL4ooj-2nxrLhWbgA2iBaWr95wKkf5peTsc-5Q6-B2uCcn9xPSQK08Y_jNVhtly3mAOdsT4Y9mQIO_oqaqEyzutypZBEu-18NkbGVwkNhG9sxvUjFXHvMoJs5iwILaDA2FhuEioIDzOy-ZjD8p928ye2v8CdPWl1xPxoBXd2KIe3RkocRDxLeeBg3wH8a9tQ5Z7fOmiXiAI8_lN57zYf078yazvLUlKzCo1pQoR25MU51d7zgI_I7H2Fb5PZGcCmfvN1Up41OfEQyMLL6JYyoP23XQ";
+const DEFAULT_RSA_EXPONENT: &str = "AQAB";
 
 pub async fn mock_oidc_config(mock_server: &MockServer, issuer: &str) {
     Mock::given(method("GET"))
@@ -47,16 +70,16 @@ pub async fn mock_oidc_config(mock_server: &MockServer, issuer: &str) {
         .await;
 }
 
-pub async fn mock_jwks(mock_server: &MockServer, keys: Vec<(String, RsaPublicKey)>) {
-    let keys = keys
+pub async fn mock_jwks(mock_server: &MockServer, kids: Vec<String>) {
+    let keys = kids
         .into_iter()
-        .map(|(kid, pub_key)| Jwk {
+        .map(|kid| Jwk {
             kty: "RSA".to_string(),
             use_: "sig".to_string(),
             alg: "RS256".to_string(),
             kid,
-            n: CUSTOM_ENGINE.encode(pub_key.n().to_bytes_be()),
-            e: CUSTOM_ENGINE.encode(pub_key.e().to_bytes_be()),
+            n: DEFAULT_RSA_MODULUS.to_owned(),
+            e: DEFAULT_RSA_EXPONENT.to_owned(),
         })
         .collect::<Vec<_>>();
     Mock::given(method("GET"))
@@ -66,14 +89,8 @@ pub async fn mock_jwks(mock_server: &MockServer, keys: Vec<(String, RsaPublicKey
         .await;
 }
 
-pub fn rsa_key_pair() -> (RsaPrivateKey, RsaPublicKey) {
-    let private_key = RsaPrivateKey::new(&mut rand::thread_rng(), 2048).unwrap();
-    let public_key = RsaPublicKey::from(&private_key);
-    (private_key, public_key)
-}
-
-pub fn jwt_from(private_key: &RsaPrivateKey, kid: &str, claims: Value) -> String {
-    let encoding_key = EncodingKey::from_rsa_der(private_key.to_pkcs1_der().unwrap().as_bytes());
+pub fn jwt_from(private_key_pem: &str, kid: &str, claims: Value) -> String {
+    let encoding_key = EncodingKey::from_rsa_pem(private_key_pem.as_bytes()).unwrap();
     let mut header = Header::new(jsonwebtoken::Algorithm::RS256);
     header.kid = Some(kid.to_owned());
     encode(&header, &claims, &encoding_key).unwrap()

--- a/tower-oauth2-resource-server/tests/service.rs
+++ b/tower-oauth2-resource-server/tests/service.rs
@@ -1,7 +1,7 @@
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 use bytes::Bytes;
-use common::{jwt_from, mock_jwks, mock_oidc_config, rsa_key_pair};
+use common::{jwt_from, mock_jwks, mock_oidc_config, DEFAULT_RSA_PRIVATE_KEY};
 use http::{header::AUTHORIZATION, HeaderName, Request, Response, StatusCode};
 use http_body_util::Full;
 use tokio::time::sleep;
@@ -59,16 +59,15 @@ async fn unauthorized_on_invalid_authorization() {
 
 #[tokio::test]
 async fn unauthorized_on_token_validation_failure() {
-    let (private_key, public_key) = rsa_key_pair();
     let mock_server = MockServer::start().await;
     mock_oidc_config(&mock_server, "https://auth-server.com").await;
-    mock_jwks(&mock_server, [("good_key".to_owned(), public_key)].to_vec()).await;
+    mock_jwks(&mock_server, ["good_key".to_owned()].to_vec()).await;
     let mut service = ServiceBuilder::new()
         .layer(default_auth_layer(&mock_server, &["https://some-resource-server.com"]).await)
         .service_fn(echo);
 
     let token = jwt_from(
-        &private_key,
+        &DEFAULT_RSA_PRIVATE_KEY,
         "good_key",
         serde_json::json!({
             "iss": "https://auth-server.com",
@@ -85,11 +84,67 @@ async fn unauthorized_on_token_validation_failure() {
 }
 
 #[tokio::test]
-async fn ok() {
-    let (private_key, public_key) = rsa_key_pair();
+async fn unauthorized_when_jwt_signed_with_unknown_key() {
     let mock_server = MockServer::start().await;
     mock_oidc_config(&mock_server, "https://auth-server.com").await;
-    mock_jwks(&mock_server, [("good_key".to_owned(), public_key)].to_vec()).await;
+    mock_jwks(&mock_server, ["good_key".to_owned()].to_vec()).await;
+    let mut service = ServiceBuilder::new()
+        .layer(default_auth_layer(&mock_server, &["https://some-resource-server.com"]).await)
+        .service_fn(echo);
+    // Needed for initial jwks fetch
+    sleep(Duration::from_millis(100)).await;
+
+    let another_rsa_key = r#"-----BEGIN PRIVATE KEY-----
+MIIEvQIBADANBgkqhkiG9w0BAQEFAASCBKcwggSjAgEAAoIBAQCsIkvGz6hM9C4G
++7wfu5KzOWxDW4PR8W12huS4aquB32UfCDZmY0HSeLqt/ulRa+z+P6KBx+LE03AH
+9/ICMfoujL4q+TQ9SDyYWeJYDyIarUkgNXbGi8ofK5D3I1uE8Aim6nyi9A/tip+h
+eLSL2Nsl+305y/pf/deYL+7pAOmQhXlE+j1cdqFyRoy8O0sOJFGczVRm0b6JVhp8
++eTZTssvGR8sqb1HX9gh3q62m5WRuv5pvLT2HnX1pa6BiVVy6dnT4wf8DVGStzXK
+dcf2OxEpRy2SZvjNKkNvxY6jeQgn1IfzacQMc+2gezd2G8bMYMqzjNM8TqdGDAhP
+pvRZCVwfAgMBAAECggEABuoPwiooOAMc8DHfciTeNS3Kz//WkTHR9E9h05iRUBOx
+o6f4S2+UPsiTsxaIt7kOmX3j4LOvQ7m8h81pXrY0Nvd3UhGVjBqhOHtv0Jq3A3xP
+cihDn6EQ2uSsm4jDjdj4d//2RrNoCmIlnF5VXkK1NtbdxlsPsRhotxfB0IE1YJUy
++lLkCmR2rPny2wL32wXQZ1TzcHnLNI0Vr/fWkf6lS1jro96XFsfmBiAV7rJsevnr
+4s03tnlE55WskNDYDLHqkI5Uk76WZ8y8PRY3XWD+Q6WFP7/AhTrTEeXOGjJT9t5E
+2YJfvHI4IQbcvDMHXA0JcwG2D+NigloJoVTlDLQ80QKBgQDrkfS46jUWu+vSV3DX
+cFhGmoji6qlVgX7kilC96IoswjW1JQVmegYv1T5PHDl9r03JUE51BAG+Yw6XRiWa
+CMueJZsA+u1UCxaIkkyv4dkcJXWmLSmfYW/NmyczZQQtdgqxgsBMsVMZFO/Sx6og
+6N0uXFhcdu1JxQ/p2kNnnHpEzwKBgQC7D/Pt1Vlouw8J2Pfg34TRR3jVHuBVWni2
+jPBhjCVmK1Lb+VMLpMBRy/Wampd2zmdJ79kStTB4R5scoU/oMUf5mteljoEsUOnA
+1OznTTAnOpbA/Mwg+Kcgt/3mjHRaNqcAnia+aWENzI3lbdjR+2Xm7I8jnbWKps8Y
+ig0cEUfnsQKBgQCBI19L66C02Mn7YlIK2Jyb/+VguBGiPT4p3SVMJmlxBfpZVnUy
+a1xu5nCk/60ImIyE+tA31714+GasSRkd6wpspOLnU6e89eMhdUoy9RWHF4X6VjHG
+HK0kwpRn2U3D+jz8eNggculCC7c5DpnWNrHh01/hOJT2ZuBFa5CeASsKAwKBgGfo
+cKMIA+Y9IhliQC7Vej2V6fTYddxzqOIeX9iPtKaQIjK2x/6LwZiuJvt+K+x+srlL
+VdUieI4XmH3KzUw5M7Xe4TLBeddYCsBmhkHlin3/+YWx5uHZvVxbV9oc4vTJrvKU
+5wiWGKdFnPx4jBv3/Z7MgKZUEGe4SQlkheu1Xa/BAoGANz6WUrXSL1jLkw71nDd/
+CX4iVdeW+740CyxNIh0Ps6AkVdQdNtlnAyjuwahWL/zJcXfdthct+B8vT07F68NE
+k7ZGOcHSWi3KlQZy3d498IZOaZDxMzfVgp0fx0mk2pKt0i7B5n/kbTReBMWyR9SK
+hyvdAY5huggrF/dBOhXOWt8=
+-----END PRIVATE KEY-----"#;
+
+    let token = jwt_from(
+        another_rsa_key,
+        "good_key",
+        serde_json::json!({
+            "iss": mock_server.uri(),
+            "sub": "Some dude",
+            "aud": vec!["https://some-resource-server.com"],
+            "nbf": SystemTime::now().duration_since(UNIX_EPOCH).unwrap().as_secs() - 10,
+            "exp": SystemTime::now().duration_since(UNIX_EPOCH).unwrap().as_secs() + 10
+        }),
+    );
+    let request = request_with_headers(vec![(AUTHORIZATION, &format!("Bearer {}", token))]);
+
+    let response = service.ready().await.unwrap().call(request).await.unwrap();
+    assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+}
+
+#[tokio::test]
+async fn ok() {
+    let mock_server = MockServer::start().await;
+    mock_oidc_config(&mock_server, "https://auth-server.com").await;
+    mock_jwks(&mock_server, ["good_key".to_owned()].to_vec()).await;
     let mut service = ServiceBuilder::new()
         .layer(default_auth_layer(&mock_server, &["https://some-resource-server.com"]).await)
         .service_fn(echo);
@@ -97,7 +152,7 @@ async fn ok() {
     sleep(Duration::from_millis(100)).await;
 
     let token = jwt_from(
-        &private_key,
+        DEFAULT_RSA_PRIVATE_KEY,
         "good_key",
         serde_json::json!({
             "iss": mock_server.uri(),

--- a/tower-oauth2-resource-server/tests/service.rs
+++ b/tower-oauth2-resource-server/tests/service.rs
@@ -67,7 +67,7 @@ async fn unauthorized_on_token_validation_failure() {
         .service_fn(echo);
 
     let token = jwt_from(
-        &DEFAULT_RSA_PRIVATE_KEY,
+        DEFAULT_RSA_PRIVATE_KEY,
         "good_key",
         serde_json::json!({
             "iss": "https://auth-server.com",


### PR DESCRIPTION
No need to dynamically generate, might as well use a hardcoded one.