### PR TITLE
Add static jwks support, key id based resolver and assorted tweaks

### DIFF
--- a/examples/axum-example/src/main.rs
+++ b/examples/axum-example/src/main.rs
@@ -16,15 +16,14 @@ async fn main() {
 
     let oauth2_resource_server = <OAuth2ResourceServer>::builder()
         .add_tenant(
-            TenantConfiguration::builder()
-                .audiences(&["tors-example"])
-                .issuer_url(format!(
-                    "http://{}:{}/realms/tors",
-                    oidc_provider_host, oidc_provider_port
-                ))
-                .build()
-                .await
-                .expect("Failed to build tenant configuration"),
+            TenantConfiguration::builder(format!(
+                "http://{}:{}/realms/tors",
+                oidc_provider_host, oidc_provider_port
+            ))
+            .audiences(&["tors-example"])
+            .build()
+            .await
+            .expect("Failed to build tenant configuration"),
         )
         .build()
         .await

--- a/examples/salvo-example/src/main.rs
+++ b/examples/salvo-example/src/main.rs
@@ -15,15 +15,14 @@ async fn main() {
 
     let oauth2_resource_server = <OAuth2ResourceServer>::builder()
         .add_tenant(
-            TenantConfiguration::builder()
-                .audiences(&["tors-example"])
-                .issuer_url(format!(
-                    "http://{}:{}/realms/tors",
-                    oidc_provider_host, oidc_provider_port
-                ))
-                .build()
-                .await
-                .expect("Failed to build TenantConfiguration"),
+            TenantConfiguration::builder(format!(
+                "http://{}:{}/realms/tors",
+                oidc_provider_host, oidc_provider_port
+            ))
+            .audiences(&["tors-example"])
+            .build()
+            .await
+            .expect("Failed to build TenantConfiguration"),
         )
         .build()
         .await

--- a/examples/tonic-example/src/main.rs
+++ b/examples/tonic-example/src/main.rs
@@ -23,15 +23,14 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     let oauth2_resource_server = <OAuth2ResourceServer>::builder()
         .add_tenant(
-            TenantConfiguration::builder()
-                .audiences(&["tors-example"])
-                .issuer_url(format!(
-                    "http://{}:{}/realms/tors",
-                    oidc_provider_host, oidc_provider_port
-                ))
-                .build()
-                .await
-                .expect("Failed to build TenantConfiguration"),
+            TenantConfiguration::builder(format!(
+                "http://{}:{}/realms/tors",
+                oidc_provider_host, oidc_provider_port
+            ))
+            .audiences(&["tors-example"])
+            .build()
+            .await
+            .expect("Failed to build TenantConfiguration"),
         )
         .build()
         .await

--- a/tower-oauth2-resource-server/src/auth_resolver.rs
+++ b/tower-oauth2-resource-server/src/auth_resolver.rs
@@ -48,3 +48,23 @@ impl<Claims> AuthorizerResolver<Claims> for IssuerAuthorizerResolver {
             .find(|authorizer| authorizer.identifier() == issuer)
     }
 }
+
+/// Selects an authorizer based on `kid` of JWTs.
+///
+#[derive(Debug)]
+pub struct KidAuthorizerResolver {}
+
+impl<Claims> AuthorizerResolver<Claims> for KidAuthorizerResolver {
+    fn select_authorizer<'a>(
+        &'a self,
+        authorizers: &'a [Authorizer<Claims>],
+        _headers: &HeaderMap,
+        unverified_jwt: &UnverifiedJwt,
+    ) -> Option<&'a Authorizer<Claims>> {
+        let header = unverified_jwt.header()?;
+        let kid = header.get("kid")?.as_str()?;
+        authorizers
+            .iter()
+            .find(|authorizer| authorizer.has_kid(kid))
+    }
+}

--- a/tower-oauth2-resource-server/src/authorizer/jwt_validate.rs
+++ b/tower-oauth2-resource-server/src/authorizer/jwt_validate.rs
@@ -20,6 +20,7 @@ use super::jwks::JwksConsumer;
 
 pub trait JwtValidator<Claims> {
     fn validate(&self, jwt: &UnverifiedJwt) -> Result<Claims, AuthError>;
+    fn has_kid(&self, kid: &str) -> bool;
 }
 
 #[derive(Default)]
@@ -58,6 +59,11 @@ where
                 reason: e.into_kind(),
             }),
         }
+    }
+
+    fn has_kid(&self, kid: &str) -> bool {
+        let inner = self.inner.read().unwrap();
+        inner.decoding_keys.contains_key(kid)
     }
 }
 

--- a/tower-oauth2-resource-server/src/authorizer/jwt_validate.rs
+++ b/tower-oauth2-resource-server/src/authorizer/jwt_validate.rs
@@ -104,6 +104,8 @@ impl OnlyJwtValidator {
         if let Some(aud) = &self.claims_validation.aud {
             required_claims.push("aud");
             validation.set_audience(aud);
+        } else {
+            validation.validate_aud = self.claims_validation.validate_aud;
         }
         validation.set_required_spec_claims(&required_claims);
         validation

--- a/tower-oauth2-resource-server/src/authorizer/jwt_validate.rs
+++ b/tower-oauth2-resource-server/src/authorizer/jwt_validate.rs
@@ -119,9 +119,9 @@ impl OnlyJwtValidatorInner {
             required_claims.push("nbf");
             validation.validate_nbf = true;
         }
-        if let Some(aud) = &claims_validation.aud {
+        if !claims_validation.aud.is_empty() {
             required_claims.push("aud");
-            validation.set_audience(aud);
+            validation.set_audience(&claims_validation.aud);
         } else {
             validation.validate_aud = claims_validation.validate_aud;
         }

--- a/tower-oauth2-resource-server/src/authorizer/token_authorizer.rs
+++ b/tower-oauth2-resource-server/src/authorizer/token_authorizer.rs
@@ -62,4 +62,8 @@ impl<Claims> Authorizer<Claims> {
     pub(crate) fn validate(&self, token: &UnverifiedJwt) -> Result<Claims, AuthError> {
         self.jwt_validator.validate(token)
     }
+
+    pub fn has_kid(&self, kid: &str) -> bool {
+        self.jwt_validator.has_kid(kid)
+    }
 }

--- a/tower-oauth2-resource-server/src/authorizer/token_authorizer.rs
+++ b/tower-oauth2-resource-server/src/authorizer/token_authorizer.rs
@@ -59,7 +59,7 @@ impl<Claims> Authorizer<Claims> {
         &self.identifier
     }
 
-    pub(crate) async fn validate(&self, token: &UnverifiedJwt) -> Result<Claims, AuthError> {
-        self.jwt_validator.validate(token).await
+    pub(crate) fn validate(&self, token: &UnverifiedJwt) -> Result<Claims, AuthError> {
+        self.jwt_validator.validate(token)
     }
 }

--- a/tower-oauth2-resource-server/src/claims.rs
+++ b/tower-oauth2-resource-server/src/claims.rs
@@ -9,6 +9,7 @@ pub struct DefaultClaims {
     pub iss: Option<String>,
     pub sub: Option<String>,
     #[serde_as(as = "OneOrMany<_, PreferMany>")]
+    #[serde(default)]
     pub aud: Vec<String>,
     pub jti: Option<String>,
 }

--- a/tower-oauth2-resource-server/src/lib.rs
+++ b/tower-oauth2-resource-server/src/lib.rs
@@ -22,8 +22,7 @@ pub mod authorizer;
 /// #[tokio::main]
 /// async fn main() {
 ///     let oauth2_resource_server = <OAuth2ResourceServer>::builder()
-///         .add_tenant(TenantConfiguration::builder()
-///             .issuer_url("https://some-auth-server.com")
+///         .add_tenant(TenantConfiguration::builder("https://some-auth-server.com")
 ///             .audiences(&["https://some-resource-server.com"])
 ///             .build().await.expect("Failed to build tenant configuration"))
 ///         .build()
@@ -46,8 +45,7 @@ pub mod authorizer;
 /// #[tokio::main]
 /// async fn main() {
 ///     let oauth2_resource_server = OAuth2ResourceServer::<MyClaims>::builder()
-///         .add_tenant(TenantConfiguration::builder()
-///             .issuer_url("https://some-auth-server.com")
+///         .add_tenant(TenantConfiguration::builder("https://some-auth-server.com")
 ///             .audiences(&["https://some-resource-server.com"])
 ///             .build().await.expect("Failed to build tenant configuration"))
 ///         .build()

--- a/tower-oauth2-resource-server/src/server.rs
+++ b/tower-oauth2-resource-server/src/server.rs
@@ -68,7 +68,7 @@ where
             .as_ref()
             .select_authorizer(&self.authorizers, request.headers(), &token)
             .ok_or(AuthError::AuthorizerNotFound)?;
-        match authorizer.validate(&token).await {
+        match authorizer.validate(&token) {
             Ok(res) => {
                 debug!("JWT validation successful ({})", authorizer.identifier());
                 request.extensions_mut().insert(res);

--- a/tower-oauth2-resource-server/src/validation.rs
+++ b/tower-oauth2-resource-server/src/validation.rs
@@ -6,11 +6,15 @@ pub struct ClaimsValidationSpec {
     pub exp: bool,
     pub nbf: bool,
     pub aud: Option<Vec<String>>,
+    pub validate_aud: bool,
 }
 
 impl ClaimsValidationSpec {
     pub fn new() -> Self {
-        Self::default()
+        Self {
+            validate_aud: true,
+            ..Default::default()
+        }
     }
 
     pub fn recommended(issuer: &str, audiences: &Vec<String>) -> Self {
@@ -34,6 +38,11 @@ impl ClaimsValidationSpec {
 
     pub fn aud(mut self, audiences: &Vec<String>) -> Self {
         self.aud = Some(audiences.to_owned());
+        self
+    }
+
+    pub fn validate_aud(mut self, validate: bool) -> Self {
+        self.validate_aud = validate;
         self
     }
 }

--- a/tower-oauth2-resource-server/src/validation.rs
+++ b/tower-oauth2-resource-server/src/validation.rs
@@ -5,7 +5,7 @@ pub struct ClaimsValidationSpec {
     pub iss: Option<String>,
     pub exp: bool,
     pub nbf: bool,
-    pub aud: Option<Vec<String>>,
+    pub aud: Vec<String>,
     pub validate_aud: bool,
 }
 
@@ -37,7 +37,7 @@ impl ClaimsValidationSpec {
     }
 
     pub fn aud(mut self, audiences: &Vec<String>) -> Self {
-        self.aud = Some(audiences.to_owned());
+        self.aud = audiences.to_owned();
         self
     }
 

--- a/tower-oauth2-resource-server/tests/service.rs
+++ b/tower-oauth2-resource-server/tests/service.rs
@@ -119,8 +119,7 @@ async fn default_auth_layer(
 ) -> OAuth2ResourceServerLayer<DefaultClaims> {
     <OAuth2ResourceServer>::builder()
         .add_tenant(
-            TenantConfiguration::builder()
-                .issuer_url(mock_server.uri())
+            TenantConfiguration::builder(mock_server.uri())
                 .audiences(audiences)
                 .build()
                 .await

--- a/tower-oauth2-resource-server/tests/service.rs
+++ b/tower-oauth2-resource-server/tests/service.rs
@@ -62,7 +62,7 @@ async fn unauthorized_on_token_validation_failure() {
     let (private_key, public_key) = rsa_key_pair();
     let mock_server = MockServer::start().await;
     mock_oidc_config(&mock_server, "https://auth-server.com").await;
-    mock_jwks(&mock_server, [("good_key".to_owned(), public_key)].to_vec()).await;
+    mock_jwks(&mock_server, &[("good_key".to_owned(), public_key)]).await;
     let mut service = ServiceBuilder::new()
         .layer(default_auth_layer(&mock_server, &["https://some-resource-server.com"]).await)
         .service_fn(echo);
@@ -89,7 +89,7 @@ async fn ok() {
     let (private_key, public_key) = rsa_key_pair();
     let mock_server = MockServer::start().await;
     mock_oidc_config(&mock_server, "https://auth-server.com").await;
-    mock_jwks(&mock_server, [("good_key".to_owned(), public_key)].to_vec()).await;
+    mock_jwks(&mock_server, &[("good_key".to_owned(), public_key)]).await;
     let mut service = ServiceBuilder::new()
         .layer(default_auth_layer(&mock_server, &["https://some-resource-server.com"]).await)
         .service_fn(echo);
@@ -111,6 +111,104 @@ async fn ok() {
 
     let response = service.ready().await.unwrap().call(request).await.unwrap();
     assert_eq!(response.status(), StatusCode::OK);
+}
+
+#[tokio::test]
+async fn ok_static() {
+    let (private_key, public_key) = rsa_key_pair();
+    let jwks = common::jwks(&[("good_key".to_string(), public_key)]);
+    let layer = <OAuth2ResourceServer>::builder()
+        .add_tenant(
+            TenantConfiguration::static_builder(serde_json::to_string(&jwks).unwrap())
+                .audiences(&["https://some-resource-server.com"])
+                .build()
+                .unwrap(),
+        )
+        .build()
+        .await
+        .expect("Failed to build OAuth2ResourceServer")
+        .into_layer();
+
+    let mut service = ServiceBuilder::new().layer(layer).service_fn(echo);
+
+    let token = jwt_from(
+        &private_key,
+        "good_key",
+        serde_json::json!({
+            "sub": "Some dude",
+            "aud": ["https://some-resource-server.com"],
+            "nbf": SystemTime::now().duration_since(UNIX_EPOCH).unwrap().as_secs() - 10,
+            "exp": SystemTime::now().duration_since(UNIX_EPOCH).unwrap().as_secs() + 10
+        }),
+    );
+    let request = request_with_headers(vec![(AUTHORIZATION, &format!("Bearer {}", token))]);
+
+    let response = service.ready().await.unwrap().call(request).await.unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+}
+
+#[tokio::test]
+async fn ok_mixed() {
+    let (static_private_key, static_public_key) = rsa_key_pair();
+    let jwks = common::jwks(&[("good_static".to_string(), static_public_key)]);
+
+    let (oidc_private_key, oidc_public_key) = rsa_key_pair();
+    let mock_server = MockServer::start().await;
+    mock_oidc_config(&mock_server, "https://auth-server.com").await;
+    mock_jwks(&mock_server, &[("good_oidc".to_owned(), oidc_public_key)]).await;
+
+    let layer = <OAuth2ResourceServer>::builder()
+        .add_tenant(
+            TenantConfiguration::static_builder(serde_json::to_string(&jwks).unwrap())
+                .audiences(&["https://some-resource-server.com"])
+                .build()
+                .unwrap(),
+        )
+        .add_tenant(
+            TenantConfiguration::builder(mock_server.uri())
+                .audiences(&["https://some-resource-server.com"])
+                .build()
+                .await
+                .unwrap(),
+        )
+        .build()
+        .await
+        .expect("Failed to build OAuth2ResourceServer")
+        .into_layer();
+
+    let mut service = ServiceBuilder::new().layer(layer).service_fn(echo);
+    // Needed for initial jwks fetch
+    sleep(Duration::from_millis(100)).await;
+
+    let token = jwt_from(
+        &oidc_private_key,
+        "good_oidc",
+        serde_json::json!({
+            "iss": mock_server.uri(),
+            "sub": "Some dude",
+            "aud": ["https://some-resource-server.com"],
+            "nbf": SystemTime::now().duration_since(UNIX_EPOCH).unwrap().as_secs() - 10,
+            "exp": SystemTime::now().duration_since(UNIX_EPOCH).unwrap().as_secs() + 10
+        }),
+    );
+    let request = request_with_headers(vec![(AUTHORIZATION, &format!("Bearer {}", token))]);
+
+    let response = service.ready().await.unwrap().call(request).await.unwrap();
+    assert_eq!(response.status(), StatusCode::OK, "OIDC request failed");
+
+    let token = jwt_from(
+        &static_private_key,
+        "good_static",
+        serde_json::json!({
+            "iss": "static",
+            "aud": ["https://some-resource-server.com"],
+            "exp": SystemTime::now().duration_since(UNIX_EPOCH).unwrap().as_secs() + 10
+        }),
+    );
+    let request = request_with_headers(vec![(AUTHORIZATION, &format!("Bearer {}", token))]);
+
+    let response = service.ready().await.unwrap().call(request).await.unwrap();
+    assert_eq!(response.status(), StatusCode::OK, "Static request failed");
 }
 
 async fn default_auth_layer(


### PR DESCRIPTION
This adds support for loading jwks from a local file (#75), allows using jwt's without an audience (which is less relevant for keys only used for a specific usage) and  adds a key id (`kid`) based resolver as an alternative to issuer based resolver.
