### PR TITLE
Remove unnecessary bounds on structs

### DIFF
--- a/tower-oauth2-resource-server/src/authorizer/token_authorizer.rs
+++ b/tower-oauth2-resource-server/src/authorizer/token_authorizer.rs
@@ -59,11 +59,16 @@ impl<Claims> Authorizer<Claims> {
         &self.identifier
     }
 
-    pub(crate) fn validate(&self, token: &UnverifiedJwt) -> Result<Claims, AuthError> {
-        self.jwt_validator.validate(token)
-    }
-
     pub fn has_kid(&self, kid: &str) -> bool {
         self.jwt_validator.has_kid(kid)
+    }
+}
+
+impl<Claims> Authorizer<Claims>
+where
+    Claims: DeserializeOwned,
+{
+    pub(crate) fn validate(&self, token: &UnverifiedJwt) -> Result<Claims, AuthError> {
+        self.jwt_validator.validate(token)
     }
 }

--- a/tower-oauth2-resource-server/src/builder.rs
+++ b/tower-oauth2-resource-server/src/builder.rs
@@ -10,10 +10,7 @@ use crate::{
 };
 
 #[derive(Debug)]
-pub struct OAuth2ResourceServerBuilder<Claims>
-where
-    Claims: Clone + DeserializeOwned + Send + Sync + 'static,
-{
+pub struct OAuth2ResourceServerBuilder<Claims> {
     tenant_configurations: Vec<TenantConfiguration>,
     auth_resolver: Option<Arc<dyn AuthorizerResolver<Claims>>>,
     phantom: PhantomData<Claims>,
@@ -28,10 +25,7 @@ where
     }
 }
 
-impl<Claims> OAuth2ResourceServerBuilder<Claims>
-where
-    Claims: Clone + DeserializeOwned + Send + Sync + 'static,
-{
+impl<Claims> OAuth2ResourceServerBuilder<Claims> {
     fn new() -> Self {
         OAuth2ResourceServerBuilder::<Claims> {
             tenant_configurations: Vec::new(),
@@ -39,7 +33,12 @@ where
             phantom: PhantomData,
         }
     }
+}
 
+impl<Claims> OAuth2ResourceServerBuilder<Claims>
+where
+    Claims: Clone + DeserializeOwned + Send + Sync + 'static,
+{
     /// Add a tenant (authorization server).
     pub fn add_tenant(mut self, tenant_configuration: TenantConfiguration) -> Self {
         self.tenant_configurations.push(tenant_configuration);
@@ -79,10 +78,7 @@ where
     }
 }
 
-impl<Claims> Default for OAuth2ResourceServerBuilder<Claims>
-where
-    Claims: Clone + DeserializeOwned + Send + Sync + 'static,
-{
+impl<Claims> Default for OAuth2ResourceServerBuilder<Claims> {
     fn default() -> Self {
         Self::new()
     }

--- a/tower-oauth2-resource-server/src/layer.rs
+++ b/tower-oauth2-resource-server/src/layer.rs
@@ -31,10 +31,7 @@ where
 }
 
 #[derive(Clone, Debug)]
-pub struct OAuth2ResourceServerLayer<Claims>
-where
-    Claims: DeserializeOwned,
-{
+pub struct OAuth2ResourceServerLayer<Claims> {
     auth_manager: OAuth2ResourceServer<Claims>,
 }
 
@@ -49,28 +46,19 @@ where
     }
 }
 
-impl<Claims> OAuth2ResourceServerLayer<Claims>
-where
-    Claims: DeserializeOwned,
-{
+impl<Claims> OAuth2ResourceServerLayer<Claims> {
     pub(crate) fn new(auth_manager: OAuth2ResourceServer<Claims>) -> Self {
         OAuth2ResourceServerLayer { auth_manager }
     }
 }
 
 #[derive(Clone, Debug)]
-pub struct OAuth2ResourceServerService<S, Claims>
-where
-    Claims: Clone + DeserializeOwned + Send + 'static,
-{
+pub struct OAuth2ResourceServerService<S, Claims> {
     inner: S,
     auth_manager: OAuth2ResourceServer<Claims>,
 }
 
-impl<S, Claims> OAuth2ResourceServerService<S, Claims>
-where
-    Claims: Clone + DeserializeOwned + Send + 'static,
-{
+impl<S, Claims> OAuth2ResourceServerService<S, Claims> {
     fn new(inner: S, auth_manager: OAuth2ResourceServer<Claims>) -> Self {
         Self {
             inner,

--- a/tower-oauth2-resource-server/src/server.rs
+++ b/tower-oauth2-resource-server/src/server.rs
@@ -86,10 +86,7 @@ where
     }
 }
 
-impl<Claims> fmt::Debug for OAuth2ResourceServer<Claims>
-where
-    Claims: DeserializeOwned,
-{
+impl<Claims> fmt::Debug for OAuth2ResourceServer<Claims> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("OAuth2AuthenticationManager").finish()
     }
@@ -97,7 +94,7 @@ where
 
 impl<Claims> OAuth2ResourceServer<Claims>
 where
-    Claims: Clone + DeserializeOwned,
+    Claims: Clone,
 {
     /// Returns a [tower layer](https://docs.rs/tower/latest/tower/trait.Layer.html).
     pub fn into_layer(&self) -> OAuth2ResourceServerLayer<Claims> {


### PR DESCRIPTION
According to [Rust API Guidelines](https://rust-lang.github.io/api-guidelines/future-proofing.html\#data-structures-do-not-duplicate-derived-trait-bounds-c-struct-bounds).