### PR TITLE
Include all workspace members by default

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,7 +2,7 @@ name: main
 on:
   push:
     branches:
-    - main
+      - main
   pull_request:
 
 jobs:
@@ -10,6 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
+      - run: sudo apt install -y protobuf-compiler
       - uses: dtolnay/rust-toolchain@stable
         with:
           components: clippy

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,9 +4,8 @@ members = [
     "examples-util",
     "examples/axum-example",
     "examples/salvo-example",
-    "examples/tonic-example"
+    "examples/tonic-example",
 ]
-default-members = ["tower-oauth2-resource-server"]
 resolver = "2"
 
 [workspace.package]


### PR DESCRIPTION
Previously `tower-oauth2-resource-server` was the only default member of the workspace.
Having all members by default will make it easier to notice issues in examples, etc.