### PR TITLE
Introduce ErrorHandler trait

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,7 @@ members = [
     "examples/axum-example",
     "examples/salvo-example",
     "examples/tonic-example",
+    "examples/custom-error-handler",
 ]
 resolver = "2"
 

--- a/examples/custom-error-handler/Cargo.toml
+++ b/examples/custom-error-handler/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "custom-error-handler"
+edition = "2021"
+
+[dependencies]
+tower-oauth2-resource-server = { path = "../../tower-oauth2-resource-server" }
+examples-util = { path = "../../examples-util" }
+
+axum = "0.8.4"
+tokio = { workspace = true, features = ["rt-multi-thread", "signal"] }
+log = { workspace = true }
+tower = { workspace = true }
+env_logger = { workspace = true }

--- a/examples/custom-error-handler/src/main.rs
+++ b/examples/custom-error-handler/src/main.rs
@@ -17,7 +17,7 @@ use tower_oauth2_resource_server::{
 struct TeapotErrorHandler;
 
 impl ErrorHandler<Body> for TeapotErrorHandler {
-    fn into_response(&self, error: &AuthError) -> Response<Body> {
+    fn map_error(&self, error: AuthError) -> Response<Body> {
         Response::builder()
             .status(StatusCode::IM_A_TEAPOT)
             .body(error.to_string().into())

--- a/examples/custom-error-handler/src/main.rs
+++ b/examples/custom-error-handler/src/main.rs
@@ -1,0 +1,95 @@
+use std::sync::Arc;
+
+use axum::{
+    body::Body,
+    http::{Response, StatusCode},
+    routing::get,
+    Extension, Router,
+};
+use log::info;
+use tokio::signal;
+use tower::ServiceBuilder;
+use tower_oauth2_resource_server::{
+    claims::DefaultClaims, error::AuthError, error_handler::ErrorHandler,
+    server::OAuth2ResourceServer, tenant::TenantConfiguration,
+};
+
+struct TeapotErrorHandler;
+
+impl ErrorHandler<Body> for TeapotErrorHandler {
+    fn handle_error(&self, error: &AuthError) -> Response<Body> {
+        Response::builder()
+            .status(StatusCode::IM_A_TEAPOT)
+            .body(error.to_string().into())
+            .unwrap()
+    }
+}
+
+#[tokio::main]
+async fn main() {
+    env_logger::init();
+    let oidc_provider = examples_util::start_oidc_provider().await;
+    let oidc_provider_host = oidc_provider.get_host().await.unwrap();
+    let oidc_provider_port = oidc_provider.get_host_port_ipv4(8080).await.unwrap();
+    info!("Running OIDC provider on port: {}", oidc_provider_port);
+
+    let oauth2_resource_server = <OAuth2ResourceServer>::builder()
+        .add_tenant(
+            TenantConfiguration::builder(format!(
+                "http://{}:{}/realms/tors",
+                oidc_provider_host, oidc_provider_port
+            ))
+            .audiences(&["tors-example"])
+            .build()
+            .await
+            .expect("Failed to build tenant configuration"),
+        )
+        .build()
+        .await
+        .expect("Failed to build OAuth2 resource server");
+
+    let app = Router::new()
+        .route("/", get(root))
+        .layer(ServiceBuilder::new().layer(
+            oauth2_resource_server.into_layer_with_error_handler(Arc::new(TeapotErrorHandler {})),
+        ));
+
+    let listener = tokio::net::TcpListener::bind("0.0.0.0:3000").await.unwrap();
+    info!("Running axum on port: 3000");
+    axum::serve(listener, app)
+        .with_graceful_shutdown(shutdown_signal())
+        .await
+        .unwrap();
+}
+
+async fn root(claims: Extension<DefaultClaims>) -> Result<(StatusCode, String), StatusCode> {
+    let sub = claims
+        .sub
+        .as_ref()
+        .ok_or(StatusCode::INTERNAL_SERVER_ERROR)?;
+    Ok((StatusCode::OK, format!("Hello, {}", sub)))
+}
+
+async fn shutdown_signal() {
+    let ctrl_c = async {
+        signal::ctrl_c()
+            .await
+            .expect("failed to install Ctrl+C handler");
+    };
+
+    #[cfg(unix)]
+    let terminate = async {
+        signal::unix::signal(signal::unix::SignalKind::terminate())
+            .expect("failed to install signal handler")
+            .recv()
+            .await;
+    };
+
+    #[cfg(not(unix))]
+    let terminate = std::future::pending::<()>();
+
+    tokio::select! {
+        _ = ctrl_c => {},
+        _ = terminate => {},
+    }
+}

--- a/examples/custom-error-handler/src/main.rs
+++ b/examples/custom-error-handler/src/main.rs
@@ -17,7 +17,7 @@ use tower_oauth2_resource_server::{
 struct TeapotErrorHandler;
 
 impl ErrorHandler<Body> for TeapotErrorHandler {
-    fn handle_error(&self, error: &AuthError) -> Response<Body> {
+    fn into_response(&self, error: &AuthError) -> Response<Body> {
         Response::builder()
             .status(StatusCode::IM_A_TEAPOT)
             .body(error.to_string().into())

--- a/tower-oauth2-resource-server/src/error.rs
+++ b/tower-oauth2-resource-server/src/error.rs
@@ -51,16 +51,17 @@ impl Display for AuthError {
 }
 impl Error for AuthError {}
 
-impl<B> From<AuthError> for Response<B>
+impl<B> From<&AuthError> for Response<B>
 where
     B: Default,
 {
-    fn from(e: AuthError) -> Self {
+    fn from(e: &AuthError) -> Self {
         let mut response = Response::builder()
             .status(StatusCode::UNAUTHORIZED)
             .body(B::default())
             .unwrap();
-        if e == AuthError::MissingAuthorizationHeader || e == AuthError::InvalidAuthorizationHeader
+        if *e == AuthError::MissingAuthorizationHeader
+            || *e == AuthError::InvalidAuthorizationHeader
         {
             response
                 .headers_mut()

--- a/tower-oauth2-resource-server/src/error.rs
+++ b/tower-oauth2-resource-server/src/error.rs
@@ -51,17 +51,16 @@ impl Display for AuthError {
 }
 impl Error for AuthError {}
 
-impl<B> From<&AuthError> for Response<B>
+impl<B> From<AuthError> for Response<B>
 where
     B: Default,
 {
-    fn from(e: &AuthError) -> Self {
+    fn from(e: AuthError) -> Self {
         let mut response = Response::builder()
             .status(StatusCode::UNAUTHORIZED)
             .body(B::default())
             .unwrap();
-        if *e == AuthError::MissingAuthorizationHeader
-            || *e == AuthError::InvalidAuthorizationHeader
+        if e == AuthError::MissingAuthorizationHeader || e == AuthError::InvalidAuthorizationHeader
         {
             response
                 .headers_mut()

--- a/tower-oauth2-resource-server/src/error_handler.rs
+++ b/tower-oauth2-resource-server/src/error_handler.rs
@@ -1,4 +1,4 @@
-use http::{header::WWW_AUTHENTICATE, HeaderValue, Response, StatusCode};
+use http::Response;
 
 use crate::error::AuthError;
 
@@ -13,17 +13,6 @@ where
     B: Default,
 {
     fn handle_error(&self, error: &AuthError) -> Response<B> {
-        let mut response = Response::builder()
-            .status(StatusCode::UNAUTHORIZED)
-            .body(B::default())
-            .unwrap();
-        if *error == AuthError::MissingAuthorizationHeader
-            || *error == AuthError::InvalidAuthorizationHeader
-        {
-            response
-                .headers_mut()
-                .insert(WWW_AUTHENTICATE, HeaderValue::from_str("Bearer").unwrap());
-        }
-        response
+        error.into()
     }
 }

--- a/tower-oauth2-resource-server/src/error_handler.rs
+++ b/tower-oauth2-resource-server/src/error_handler.rs
@@ -1,0 +1,29 @@
+use http::{header::WWW_AUTHENTICATE, HeaderValue, Response, StatusCode};
+
+use crate::error::AuthError;
+
+pub trait ErrorHandler<B> {
+    fn handle_error(&self, error: &AuthError) -> Response<B>;
+}
+
+pub struct DefaultErrorHandler;
+
+impl<B> ErrorHandler<B> for DefaultErrorHandler
+where
+    B: Default,
+{
+    fn handle_error(&self, error: &AuthError) -> Response<B> {
+        let mut response = Response::builder()
+            .status(StatusCode::UNAUTHORIZED)
+            .body(B::default())
+            .unwrap();
+        if *error == AuthError::MissingAuthorizationHeader
+            || *error == AuthError::InvalidAuthorizationHeader
+        {
+            response
+                .headers_mut()
+                .insert(WWW_AUTHENTICATE, HeaderValue::from_str("Bearer").unwrap());
+        }
+        response
+    }
+}

--- a/tower-oauth2-resource-server/src/error_handler.rs
+++ b/tower-oauth2-resource-server/src/error_handler.rs
@@ -3,7 +3,7 @@ use http::Response;
 use crate::error::AuthError;
 
 pub trait ErrorHandler<B>: Send + Sync {
-    fn into_response(&self, error: &AuthError) -> Response<B>;
+    fn map_error(&self, error: AuthError) -> Response<B>;
 }
 
 pub struct DefaultErrorHandler;
@@ -12,7 +12,7 @@ impl<B> ErrorHandler<B> for DefaultErrorHandler
 where
     B: Default,
 {
-    fn into_response(&self, error: &AuthError) -> Response<B> {
+    fn map_error(&self, error: AuthError) -> Response<B> {
         error.into()
     }
 }

--- a/tower-oauth2-resource-server/src/error_handler.rs
+++ b/tower-oauth2-resource-server/src/error_handler.rs
@@ -3,7 +3,7 @@ use http::Response;
 use crate::error::AuthError;
 
 pub trait ErrorHandler<B>: Send + Sync {
-    fn handle_error(&self, error: &AuthError) -> Response<B>;
+    fn into_response(&self, error: &AuthError) -> Response<B>;
 }
 
 pub struct DefaultErrorHandler;
@@ -12,7 +12,7 @@ impl<B> ErrorHandler<B> for DefaultErrorHandler
 where
     B: Default,
 {
-    fn handle_error(&self, error: &AuthError) -> Response<B> {
+    fn into_response(&self, error: &AuthError) -> Response<B> {
         error.into()
     }
 }

--- a/tower-oauth2-resource-server/src/error_handler.rs
+++ b/tower-oauth2-resource-server/src/error_handler.rs
@@ -2,7 +2,7 @@ use http::{header::WWW_AUTHENTICATE, HeaderValue, Response, StatusCode};
 
 use crate::error::AuthError;
 
-pub trait ErrorHandler<B> {
+pub trait ErrorHandler<B>: Send + Sync {
     fn handle_error(&self, error: &AuthError) -> Response<B>;
 }
 

--- a/tower-oauth2-resource-server/src/layer.rs
+++ b/tower-oauth2-resource-server/src/layer.rs
@@ -144,6 +144,9 @@ where
     }
 }
 
+type AuthorizeFuture<S, ReqBody, Claims, ResBody> =
+    <OAuth2ResourceServerService<S, Claims, ResBody> as Authorize<ReqBody, ResBody>>::Future;
+
 #[pin_project]
 pub struct ResponseFuture<S, ReqBody, Claims, ResBody>
 where
@@ -153,10 +156,7 @@ where
     ResBody: Send + 'static,
 {
     #[pin]
-    state: State<
-        <OAuth2ResourceServerService<S, Claims, ResBody> as Authorize<ReqBody, ResBody>>::Future,
-        S::Future,
-    >,
+    state: State<AuthorizeFuture<S, ReqBody, Claims, ResBody>, S::Future>,
     service: S,
 }
 

--- a/tower-oauth2-resource-server/src/layer.rs
+++ b/tower-oauth2-resource-server/src/layer.rs
@@ -33,7 +33,7 @@ where
         Box::pin(async move {
             match auth.authorize_request(request).await {
                 Ok(request) => Ok(request),
-                Err(error) => Err(error_handler.into_response(&error)),
+                Err(error) => Err(error_handler.map_error(error)),
             }
         })
     }

--- a/tower-oauth2-resource-server/src/layer.rs
+++ b/tower-oauth2-resource-server/src/layer.rs
@@ -33,7 +33,7 @@ where
         Box::pin(async move {
             match auth.authorize_request(request).await {
                 Ok(request) => Ok(request),
-                Err(error) => Err(error_handler.handle_error(&error)),
+                Err(error) => Err(error_handler.into_response(&error)),
             }
         })
     }

--- a/tower-oauth2-resource-server/src/layer.rs
+++ b/tower-oauth2-resource-server/src/layer.rs
@@ -5,79 +5,129 @@ use serde::de::DeserializeOwned;
 
 use std::{
     pin::Pin,
+    sync::Arc,
     task::{ready, Context, Poll},
 };
 use tower::{Layer, Service};
 
-use crate::{error::AuthError, server::OAuth2ResourceServer};
+use crate::{error_handler::ErrorHandler, server::OAuth2ResourceServer};
 
-trait Authorize<B> {
-    type Future: Future<Output = Result<Request<B>, AuthError>>;
+trait Authorize<B, ResBody> {
+    type Future: Future<Output = Result<Request<B>, Response<ResBody>>>;
 
     fn authorize(&mut self, request: Request<B>) -> Self::Future;
 }
 
-impl<S, ReqBody, Claims> Authorize<ReqBody> for OAuth2ResourceServerService<S, Claims>
+impl<S, ReqBody, Claims, ResBody> Authorize<ReqBody, ResBody>
+    for OAuth2ResourceServerService<S, Claims, ResBody>
 where
     Claims: DeserializeOwned + Clone + Send + Sync + 'static,
     ReqBody: Send + 'static,
+    ResBody: Send + 'static,
 {
-    type Future = BoxFuture<'static, Result<Request<ReqBody>, AuthError>>;
+    type Future = BoxFuture<'static, Result<Request<ReqBody>, Response<ResBody>>>;
 
     fn authorize(&mut self, request: Request<ReqBody>) -> Self::Future {
         let auth = self.auth_manager.clone();
-        Box::pin(async move { auth.authorize_request(request).await })
+        let error_handler = self.error_handler.clone();
+        Box::pin(async move {
+            match auth.authorize_request(request).await {
+                Ok(request) => Ok(request),
+                Err(error) => Err(error_handler.handle_error(&error)),
+            }
+        })
     }
 }
 
-#[derive(Clone, Debug)]
-pub struct OAuth2ResourceServerLayer<Claims> {
+pub struct OAuth2ResourceServerLayer<Claims, ResBody> {
     auth_manager: OAuth2ResourceServer<Claims>,
+    error_handler: Arc<dyn ErrorHandler<ResBody>>,
 }
 
-impl<S, Claims> Layer<S> for OAuth2ResourceServerLayer<Claims>
+impl<Claims, ResBody> Clone for OAuth2ResourceServerLayer<Claims, ResBody>
+where
+    Claims: Clone,
+{
+    fn clone(&self) -> Self {
+        Self {
+            auth_manager: self.auth_manager.clone(),
+            error_handler: self.error_handler.clone(),
+        }
+    }
+}
+
+impl<S, Claims, ResBody> Layer<S> for OAuth2ResourceServerLayer<Claims, ResBody>
 where
     Claims: Clone + DeserializeOwned + Send + 'static,
 {
-    type Service = OAuth2ResourceServerService<S, Claims>;
+    type Service = OAuth2ResourceServerService<S, Claims, ResBody>;
 
     fn layer(&self, inner: S) -> Self::Service {
-        OAuth2ResourceServerService::new(inner, self.auth_manager.clone())
+        OAuth2ResourceServerService::new(
+            inner,
+            self.auth_manager.clone(),
+            self.error_handler.clone(),
+        )
     }
 }
 
-impl<Claims> OAuth2ResourceServerLayer<Claims> {
-    pub(crate) fn new(auth_manager: OAuth2ResourceServer<Claims>) -> Self {
-        OAuth2ResourceServerLayer { auth_manager }
+impl<Claims, ResBody> OAuth2ResourceServerLayer<Claims, ResBody> {
+    pub(crate) fn new(
+        auth_manager: OAuth2ResourceServer<Claims>,
+        error_handler: Arc<dyn ErrorHandler<ResBody>>,
+    ) -> Self {
+        OAuth2ResourceServerLayer {
+            auth_manager,
+            error_handler,
+        }
     }
 }
 
-#[derive(Clone, Debug)]
-pub struct OAuth2ResourceServerService<S, Claims> {
+pub struct OAuth2ResourceServerService<S, Claims, ResBody> {
     inner: S,
     auth_manager: OAuth2ResourceServer<Claims>,
+    error_handler: Arc<dyn ErrorHandler<ResBody>>,
 }
 
-impl<S, Claims> OAuth2ResourceServerService<S, Claims> {
-    fn new(inner: S, auth_manager: OAuth2ResourceServer<Claims>) -> Self {
+impl<S, Claims, ResBody> Clone for OAuth2ResourceServerService<S, Claims, ResBody>
+where
+    S: Clone,
+    Claims: Clone,
+{
+    fn clone(&self) -> Self {
+        Self {
+            inner: self.inner.clone(),
+            auth_manager: self.auth_manager.clone(),
+            error_handler: self.error_handler.clone(),
+        }
+    }
+}
+
+impl<S, Claims, ResBody> OAuth2ResourceServerService<S, Claims, ResBody> {
+    fn new(
+        inner: S,
+        auth_manager: OAuth2ResourceServer<Claims>,
+        error_handler: Arc<dyn ErrorHandler<ResBody>>,
+    ) -> Self {
         Self {
             inner,
             auth_manager,
+            error_handler,
         }
     }
 }
 
 impl<S, ReqBody, ResBody, Claims> Service<Request<ReqBody>>
-    for OAuth2ResourceServerService<S, Claims>
+    for OAuth2ResourceServerService<S, Claims, ResBody>
 where
     S: Service<Request<ReqBody>, Response = Response<ResBody>> + Clone,
-    ResBody: Default,
+    ResBody: Default + Send + 'static,
     Claims: Clone + DeserializeOwned + Send + Sync + 'static,
     ReqBody: Send + 'static,
 {
     type Response = S::Response;
     type Error = S::Error;
-    type Future = ResponseFuture<S, ReqBody, Claims>;
+    type Future = ResponseFuture<S, ReqBody, Claims, ResBody>;
 
     fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
         self.inner.poll_ready(cx)
@@ -95,14 +145,18 @@ where
 }
 
 #[pin_project]
-pub struct ResponseFuture<S, ReqBody, Claims>
+pub struct ResponseFuture<S, ReqBody, Claims, ResBody>
 where
-    S: Service<Request<ReqBody>>,
+    S: Service<Request<ReqBody>, Response = Response<ResBody>>,
     ReqBody: Send + 'static,
     Claims: Clone + DeserializeOwned + Send + Sync + 'static,
+    ResBody: Send + 'static,
 {
     #[pin]
-    state: State<<OAuth2ResourceServerService<S, Claims> as Authorize<ReqBody>>::Future, S::Future>,
+    state: State<
+        <OAuth2ResourceServerService<S, Claims, ResBody> as Authorize<ReqBody, ResBody>>::Future,
+        S::Future,
+    >,
     service: S,
 }
 
@@ -118,10 +172,10 @@ enum State<A, SFut> {
     },
 }
 
-impl<S, ReqBody, B, Claims> Future for ResponseFuture<S, ReqBody, Claims>
+impl<S, ReqBody, B, Claims> Future for ResponseFuture<S, ReqBody, Claims, B>
 where
     S: Service<Request<ReqBody>, Response = Response<B>>,
-    B: Default,
+    B: Default + Send + 'static,
     ReqBody: Send + 'static,
     Claims: Clone + DeserializeOwned + Send + Sync + 'static,
 {
@@ -140,8 +194,7 @@ where
                             this.state.set(State::Authorized { fut })
                         }
                         Err(res) => {
-                            let response = Response::<B>::from(res);
-                            return Poll::Ready(Ok(response));
+                            return Poll::Ready(Ok(res));
                         }
                     };
                 }

--- a/tower-oauth2-resource-server/src/lib.rs
+++ b/tower-oauth2-resource-server/src/lib.rs
@@ -121,6 +121,8 @@ pub mod tenant;
 /// TODO: Docs!
 pub mod error_handler;
 
-mod error;
+/// TODO: Docs!
+pub mod error;
+
 mod jwt_extract;
 mod oidc;

--- a/tower-oauth2-resource-server/src/lib.rs
+++ b/tower-oauth2-resource-server/src/lib.rs
@@ -118,6 +118,9 @@ pub mod jwt_unverified;
 /// via [add_tenant](crate::builder::OAuth2ResourceServerBuilder::add_tenant).
 pub mod tenant;
 
+/// TODO: Docs!
+pub mod error_handler;
+
 mod error;
 mod jwt_extract;
 mod oidc;

--- a/tower-oauth2-resource-server/src/lib.rs
+++ b/tower-oauth2-resource-server/src/lib.rs
@@ -118,10 +118,16 @@ pub mod jwt_unverified;
 /// via [add_tenant](crate::builder::OAuth2ResourceServerBuilder::add_tenant).
 pub mod tenant;
 
-/// TODO: Docs!
+/// [ErrorHandler](crate::error_handler::ErrorHandler) is used to produce a HTTP response
+/// on authentication error.
+///
+/// A custom implementation may be provided by using [into_layer_with_error_handler](crate::server::OAuth2ResourceServer::into_layer_with_error_handler).
+///
+/// If no implementation is provided, [DefaultErrorHandler](crate::error_handler::DefaultErrorHandler)
+/// will be used.
 pub mod error_handler;
 
-/// TODO: Docs!
+/// Error types
 pub mod error;
 
 mod jwt_extract;

--- a/tower-oauth2-resource-server/src/server.rs
+++ b/tower-oauth2-resource-server/src/server.rs
@@ -11,7 +11,7 @@ use crate::{
     authorizer::token_authorizer::Authorizer,
     claims::DefaultClaims,
     error::{AuthError, StartupError},
-    error_handler::DefaultErrorHandler,
+    error_handler::{DefaultErrorHandler, ErrorHandler},
     jwt_extract::{BearerTokenJwtExtractor, JwtExtractor},
     layer::OAuth2ResourceServerLayer,
     tenant::TenantConfiguration,
@@ -103,5 +103,13 @@ where
         ResBody: Default,
     {
         OAuth2ResourceServerLayer::new(self.clone(), Arc::new(DefaultErrorHandler))
+    }
+
+    /// Returns a [tower layer] (https://docs.rs/tower/latest/tower/trait.Layer.html) that uses a custom [ErrorHandler](INSERT-LINK) implementation.
+    pub fn into_layer_with_error_handler<ResBody>(
+        &self,
+        error_handler: Arc<dyn ErrorHandler<ResBody>>,
+    ) -> OAuth2ResourceServerLayer<Claims, ResBody> {
+        OAuth2ResourceServerLayer::new(self.clone(), error_handler)
     }
 }

--- a/tower-oauth2-resource-server/src/server.rs
+++ b/tower-oauth2-resource-server/src/server.rs
@@ -11,6 +11,7 @@ use crate::{
     authorizer::token_authorizer::Authorizer,
     claims::DefaultClaims,
     error::{AuthError, StartupError},
+    error_handler::DefaultErrorHandler,
     jwt_extract::{BearerTokenJwtExtractor, JwtExtractor},
     layer::OAuth2ResourceServerLayer,
     tenant::TenantConfiguration,
@@ -97,7 +98,10 @@ where
     Claims: Clone,
 {
     /// Returns a [tower layer](https://docs.rs/tower/latest/tower/trait.Layer.html).
-    pub fn into_layer(&self) -> OAuth2ResourceServerLayer<Claims> {
-        OAuth2ResourceServerLayer::new(self.clone())
+    pub fn into_layer<ResBody>(&self) -> OAuth2ResourceServerLayer<Claims, ResBody>
+    where
+        ResBody: Default,
+    {
+        OAuth2ResourceServerLayer::new(self.clone(), Arc::new(DefaultErrorHandler))
     }
 }

--- a/tower-oauth2-resource-server/src/server.rs
+++ b/tower-oauth2-resource-server/src/server.rs
@@ -105,7 +105,7 @@ where
         OAuth2ResourceServerLayer::new(self.clone(), Arc::new(DefaultErrorHandler))
     }
 
-    /// Returns a [tower layer] (https://docs.rs/tower/latest/tower/trait.Layer.html) that uses a custom [ErrorHandler](INSERT-LINK) implementation.
+    /// Returns a [tower layer](https://docs.rs/tower/latest/tower/trait.Layer.html) that uses a custom [ErrorHandler] implementation.
     pub fn into_layer_with_error_handler<ResBody>(
         &self,
         error_handler: Arc<dyn ErrorHandler<ResBody>>,

--- a/tower-oauth2-resource-server/src/server.rs
+++ b/tower-oauth2-resource-server/src/server.rs
@@ -98,7 +98,7 @@ where
     Claims: Clone,
 {
     /// Returns a [tower layer](https://docs.rs/tower/latest/tower/trait.Layer.html).
-    pub fn into_layer<ResBody>(&self) -> OAuth2ResourceServerLayer<Claims, ResBody>
+    pub fn into_layer<ResBody>(&self) -> OAuth2ResourceServerLayer<ResBody, Claims>
     where
         ResBody: Default,
     {
@@ -109,7 +109,7 @@ where
     pub fn into_layer_with_error_handler<ResBody>(
         &self,
         error_handler: Arc<dyn ErrorHandler<ResBody>>,
-    ) -> OAuth2ResourceServerLayer<Claims, ResBody> {
+    ) -> OAuth2ResourceServerLayer<ResBody, Claims> {
         OAuth2ResourceServerLayer::new(self.clone(), error_handler)
     }
 }

--- a/tower-oauth2-resource-server/tests/service.rs
+++ b/tower-oauth2-resource-server/tests/service.rs
@@ -6,21 +6,22 @@ use std::{
 use bytes::Bytes;
 use common::{jwt_from, mock_jwks, mock_oidc_config, rsa_keys};
 use http::{header::AUTHORIZATION, HeaderName, Request, Response, StatusCode};
-use http_body_util::Full;
+use http_body_util::{BodyExt, Full};
 use serde::{Deserialize, Serialize};
 use tokio::time::sleep;
 use tower::{BoxError, Service, ServiceBuilder, ServiceExt};
 
 use tower_oauth2_resource_server::{
-    auth_resolver::KidAuthorizerResolver, claims::DefaultClaims, layer::OAuth2ResourceServerLayer,
-    server::OAuth2ResourceServer, tenant::TenantConfiguration, validation::ClaimsValidationSpec,
+    auth_resolver::KidAuthorizerResolver, claims::DefaultClaims, error::AuthError,
+    error_handler::ErrorHandler, layer::OAuth2ResourceServerLayer, server::OAuth2ResourceServer,
+    tenant::TenantConfiguration, validation::ClaimsValidationSpec,
 };
 use wiremock::MockServer;
 
 mod common;
 
 // Needed for initial jwks fetch
-const START_UP_DELAY_MS: Duration = Duration::from_millis(150);
+const START_UP_DELAY_MS: Duration = Duration::from_millis(500);
 
 #[tokio::test]
 async fn unauthorized_on_missing_authorization() {
@@ -336,6 +337,50 @@ async fn propagates_jwt_claims() {
 
     let body = response.into_body();
     assert_eq!(body, "{\"sub\":\"Some dude\",\"role\":\"superuser\"}");
+}
+
+struct TeapotErrorHandler {}
+
+impl ErrorHandler<Full<Bytes>> for TeapotErrorHandler {
+    fn handle_error(&self, _: &AuthError) -> Response<Full<Bytes>> {
+        Response::builder()
+            .status(StatusCode::IM_A_TEAPOT)
+            .body(Full::new("With a body".into()))
+            .unwrap()
+    }
+}
+
+#[tokio::test]
+async fn custom_error_handler() {
+    let mock_server = MockServer::start().await;
+    mock_oidc_config(&mock_server, "").await;
+    let mut service = ServiceBuilder::new()
+        .layer(
+            <OAuth2ResourceServer>::builder()
+                .add_tenant(
+                    TenantConfiguration::builder(mock_server.uri())
+                        .audiences(&Vec::<String>::new())
+                        .build()
+                        .await
+                        .unwrap(),
+                )
+                .build()
+                .await
+                .expect("Failed to build OAuth2ResourceServer")
+                .into_layer_with_error_handler(Arc::new(TeapotErrorHandler {})),
+        )
+        .service_fn(echo);
+    sleep(START_UP_DELAY_MS).await;
+
+    let request = request_with_headers(Vec::new());
+
+    let response = service.ready().await.unwrap().call(request).await.unwrap();
+    assert_eq!(response.status(), StatusCode::IM_A_TEAPOT);
+    let body = response.into_body().collect().await.unwrap();
+    assert_eq!(
+        String::from_utf8(body.to_bytes().into()).unwrap(),
+        "With a body".to_owned()
+    );
 }
 
 async fn default_auth_layer<T>(

--- a/tower-oauth2-resource-server/tests/service.rs
+++ b/tower-oauth2-resource-server/tests/service.rs
@@ -338,10 +338,13 @@ async fn propagates_jwt_claims() {
     assert_eq!(body, "{\"sub\":\"Some dude\",\"role\":\"superuser\"}");
 }
 
-async fn default_auth_layer(
+async fn default_auth_layer<T>(
     mock_server: &MockServer,
     audiences: &[impl ToString],
-) -> OAuth2ResourceServerLayer<DefaultClaims> {
+) -> OAuth2ResourceServerLayer<DefaultClaims, T>
+where
+    T: Default,
+{
     <OAuth2ResourceServer>::builder()
         .add_tenant(
             TenantConfiguration::builder(mock_server.uri())

--- a/tower-oauth2-resource-server/tests/service.rs
+++ b/tower-oauth2-resource-server/tests/service.rs
@@ -342,7 +342,7 @@ async fn propagates_jwt_claims() {
 struct TeapotErrorHandler {}
 
 impl ErrorHandler<Full<Bytes>> for TeapotErrorHandler {
-    fn into_response(&self, _: &AuthError) -> Response<Full<Bytes>> {
+    fn map_error(&self, _: AuthError) -> Response<Full<Bytes>> {
         Response::builder()
             .status(StatusCode::IM_A_TEAPOT)
             .body(Full::new("With a body".into()))

--- a/tower-oauth2-resource-server/tests/service.rs
+++ b/tower-oauth2-resource-server/tests/service.rs
@@ -342,7 +342,7 @@ async fn propagates_jwt_claims() {
 struct TeapotErrorHandler {}
 
 impl ErrorHandler<Full<Bytes>> for TeapotErrorHandler {
-    fn handle_error(&self, _: &AuthError) -> Response<Full<Bytes>> {
+    fn into_response(&self, _: &AuthError) -> Response<Full<Bytes>> {
         Response::builder()
             .status(StatusCode::IM_A_TEAPOT)
             .body(Full::new("With a body".into()))

--- a/tower-oauth2-resource-server/tests/service.rs
+++ b/tower-oauth2-resource-server/tests/service.rs
@@ -386,7 +386,7 @@ async fn custom_error_handler() {
 async fn default_auth_layer<T>(
     mock_server: &MockServer,
     audiences: &[impl ToString],
-) -> OAuth2ResourceServerLayer<DefaultClaims, T>
+) -> OAuth2ResourceServerLayer<T, DefaultClaims>
 where
     T: Default,
 {


### PR DESCRIPTION
The ErrorHandler trait is responsible for converting from an AuthError to a Response<T>. A custom implementation may be provided by using `into_layer_with_error_handler` instead of `into_layer`.

This enables custom error responses, e.g. with more detailed error causes, or arbitrary formats (text/html, json, problem details, etc). It could also be used to run other arbitrary code on auth failures, for example write a log line, increment metrics, etc.

**Note**! This may be breaking, depending on usage. As long as HTTP response body type can be inferred when calling [into_layer](https://docs.rs/tower-oauth2-resource-server/latest/tower_oauth2_resource_server/server/struct.OAuth2ResourceServer.html#method.into_layer) it should work fine. Otherwise, you'll need to add the ResBody type parameter explicitly, e.g. `.into_layer::<axum::body::Body>()`.