### PR TITLE
Use more sensible dependency version ranges

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ members = [
 resolver = "2"
 
 [workspace.dependencies]
-log = "0.4.27"
+log = "0.4.28"
 tokio = "1.47.1"
 tower = "0.5.2"
-env_logger = "0.11.6"
+env_logger = "0.11.8"

--- a/examples/tonic-example/Cargo.toml
+++ b/examples/tonic-example/Cargo.toml
@@ -6,13 +6,13 @@ edition = "2021"
 tower-oauth2-resource-server = { path = "../../tower-oauth2-resource-server" }
 examples-util = { path = "../../examples-util" }
 
-tonic = "0.14.1"
+tonic = "0.14.2"
 prost = "0.14.1"
-tonic-prost = "0.14.1"
+tonic-prost = "0.14.2"
 tokio = { workspace = true, features = ["rt-multi-thread", "signal"] }
 log = { workspace = true }
 tower = { workspace = true }
 env_logger = { workspace = true }
 
 [build-dependencies]
-tonic-prost-build = "0.14.1"
+tonic-prost-build = "0.14.2"

--- a/tower-oauth2-resource-server/Cargo.toml
+++ b/tower-oauth2-resource-server/Cargo.toml
@@ -15,16 +15,16 @@ exclude = ["tests"]
 [dependencies]
 async-trait = "0.1.89"
 base64 = "0.22.1"
-futures-util = "0.3.30"
+futures-util = "0.3.31"
 http = "1.3.1"
 jsonwebtoken = "9.3.1"
 log = { workspace = true }
 mockall_double = "0.3.1"
 pin-project = "1.1.10"
 reqwest = { version = "0.12.23", default-features = false, features = ["json"] }
-serde = "1.0.219"
-serde_json = "1.0.143"
-serde_with = "3.14.0"
+serde = "1.0.227"
+serde_json = "1.0.145"
+serde_with = "3.14.1"
 tokio = { workspace = true, features = ["rt", "sync", "time"] }
 tower = { workspace = true }
 url = { version = "2.5.7", features = ["serde"] }
@@ -32,7 +32,7 @@ url = { version = "2.5.7", features = ["serde"] }
 [dev-dependencies]
 http-body-util = "0.1.3"
 bytes = "1.10.1"
-lazy_static = "1.4.0"
+lazy_static = "1.5.0"
 mockall = "0.13.1"
 tower = { workspace = true, features = ["util"] }
 tokio = { workspace = true, features = ["rt-multi-thread"] }


### PR DESCRIPTION
- Use `major.minor` ranges for crate dependencies to allow compatible
  patch updates while preventing accidental breaking upgrades.

- Use `major.minor.patch` for dev-dependencies example crates.