### PR TITLE
Parse issuer from OIDC config

### DIFF
--- a/tower-oauth2-resource-server/src/oidc.rs
+++ b/tower-oauth2-resource-server/src/oidc.rs
@@ -11,7 +11,7 @@ use crate::error::StartupError;
 #[derive(Clone, Debug, Deserialize)]
 pub(crate) struct OidcConfig {
     pub jwks_uri: Url,
-    pub issuer: Url,
+    pub issuer: String,
     pub claims_supported: Option<Vec<String>>,
 }
 

--- a/tower-oauth2-resource-server/src/oidc.rs
+++ b/tower-oauth2-resource-server/src/oidc.rs
@@ -11,6 +11,7 @@ use crate::error::StartupError;
 #[derive(Clone, Debug, Deserialize)]
 pub(crate) struct OidcConfig {
     pub jwks_uri: Url,
+    pub issuer: Url,
     pub claims_supported: Option<Vec<String>>,
 }
 

--- a/tower-oauth2-resource-server/src/tenant.rs
+++ b/tower-oauth2-resource-server/src/tenant.rs
@@ -275,6 +275,7 @@ fn recommended_claims_spec(
                 claims_spec = claims_spec.nbf(true);
             }
         }
+        claims_spec = claims_spec.iss(config.issuer.as_str());
     }
     claims_spec
 }


### PR DESCRIPTION
As suggested by @TuxCoder in #126, issuer is now parsed from response of the OIDC discovery endpoint, instead of provided as argument to [TenantConfigurationBuilder](https://docs.rs/tower-oauth2-resource-server/latest/tower_oauth2_resource_server/tenant/struct.TenantConfiguration.html#method.builder).

According to [OIDC specification](https://openid.net/specs/openid-connect-discovery-1_0.html#IssuerDiscovery) issuer is a required property, so I think this should be fine.

If this causes issues, the issuer to be verified may be overridden by providing a custom [ClaimsValidationSpec](https://docs.rs/tower-oauth2-resource-server/latest/tower_oauth2_resource_server/tenant/struct.TenantConfigurationBuilder.html#method.claims_validation).