### PR TITLE
Ignore audience validation if no audience is set

### DIFF
--- a/tower-oauth2-resource-server/src/authorizer/jwt_validate.rs
+++ b/tower-oauth2-resource-server/src/authorizer/jwt_validate.rs
@@ -123,7 +123,7 @@ impl OnlyJwtValidatorInner {
             required_claims.push("aud");
             validation.set_audience(&claims_validation.aud);
         } else {
-            validation.validate_aud = claims_validation.validate_aud;
+            validation.validate_aud = false;
         }
         validation.set_required_spec_claims(&required_claims);
         validation

--- a/tower-oauth2-resource-server/src/tenant.rs
+++ b/tower-oauth2-resource-server/src/tenant.rs
@@ -262,9 +262,7 @@ fn recommended_claims_spec(
 ) -> ClaimsValidationSpec {
     let mut claims_spec = ClaimsValidationSpec::new().exp(true);
     if !audiences.is_empty() {
-        claims_spec = claims_spec.aud(audiences).validate_aud(true);
-    } else {
-        claims_spec = claims_spec.validate_aud(false)
+        claims_spec = claims_spec.aud(audiences);
     }
 
     if let Some(config) = &oidc_config {

--- a/tower-oauth2-resource-server/src/tenant.rs
+++ b/tower-oauth2-resource-server/src/tenant.rs
@@ -260,7 +260,13 @@ fn recommended_claims_spec(
     audiences: &Vec<String>,
     oidc_config: &Option<OidcConfig>,
 ) -> ClaimsValidationSpec {
-    let mut claims_spec = ClaimsValidationSpec::new().aud(audiences).exp(true);
+    let mut claims_spec = ClaimsValidationSpec::new().exp(true);
+    if !audiences.is_empty() {
+        claims_spec = claims_spec.aud(audiences).validate_aud(true);
+    } else {
+        claims_spec = claims_spec.validate_aud(false)
+    }
+
     if let Some(config) = &oidc_config {
         if let Some(claims_supported) = &config.claims_supported {
             if claims_supported.contains(&"nbf".to_owned()) {

--- a/tower-oauth2-resource-server/src/validation.rs
+++ b/tower-oauth2-resource-server/src/validation.rs
@@ -6,13 +6,11 @@ pub struct ClaimsValidationSpec {
     pub exp: bool,
     pub nbf: bool,
     pub aud: Vec<String>,
-    pub validate_aud: bool,
 }
 
 impl ClaimsValidationSpec {
     pub fn new() -> Self {
         Self {
-            validate_aud: true,
             ..Default::default()
         }
     }
@@ -38,11 +36,6 @@ impl ClaimsValidationSpec {
 
     pub fn aud(mut self, audiences: &Vec<String>) -> Self {
         self.aud = audiences.to_owned();
-        self
-    }
-
-    pub fn validate_aud(mut self, validate: bool) -> Self {
-        self.validate_aud = validate;
         self
     }
 }


### PR DESCRIPTION
As suggested by @TuxCoder in #127 the `aud` claim is now only validated if audiences are actually provided.